### PR TITLE
RFC: support load EBPF program written in C

### DIFF
--- a/redbpf/src/error.rs
+++ b/redbpf/src/error.rs
@@ -20,6 +20,7 @@ pub enum Error {
     SymbolNotFound(String),
     ProgramAlreadyLoaded,
     ProgramNotLoaded,
+    ElfError,
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;


### PR DESCRIPTION
Durng my usage of redbpf loading C program, I found a issue that prevents me from successfully load the ebpf program into kernel. After some digging, I found that it is casued by different "maps" section usage protocol.

In C program, the section "maps" contains all maps definitions without actual names of the map. Also, the symbols are used to mark out those maps, with the `st_value` determines the offset into the `maps` section. However, current implementation assumes the `shndx` (section header index) can be used to find the individual map.

This PR is a temp fix of this problem. With this PR, the C program is loadable now (tested with [this program](https://github.com/aquasecurity/tracee/blob/main/tracee-ebpf/tracee/tracee.bpf.c), although I have met several issues I believe not caused by this one. For example, the `kprobe/send_bin` is not attachable, because not found).

I know this is not a clean PR (the error is modified to assist my debugging purpose), I leave this PR here as a RFC. If you guys agree with my primary fixing, I will submit a clean fix of this problem without any other modifications. (The unclear error is another problem, but out of the topic in this PR) 