### PR TITLE
changes "blk_account_io_completion" to "blk_account_io_done" for kernel version >= 5.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ On Debian, Ubuntu and derivatives you can install the dependencies running:
 			llvm-11-dev libclang-11-dev linux-headers-$(uname -r)
 
 If your distribution doesn't have LLVM 11, you can add the [official LLVM
-APT repository](apt.llvm.org) to your `sources.list`.
+APT repository](https://apt.llvm.org) to your `sources.list`.
 
 ## Installing dependencies on RPM based distributions
 

--- a/examples/example-userspace/examples/biolatpcts.rs
+++ b/examples/example-userspace/examples/biolatpcts.rs
@@ -107,15 +107,15 @@ async fn main() -> ! {
         let mut lat_total = 0;
 
         for i in 0usize..100 {
-            let v: u64 = cur_lat_100ms.get(i as i32).unwrap().iter().sum();
+            let v: u64 = cur_lat_100ms.get(i as u32).unwrap().iter().sum();
             lat_100ms[i] = cmp::max(v - last_lat_100ms[i], 0);
             last_lat_100ms[i] = v;
 
-            let v: u64 = cur_lat_1ms.get(i as i32).unwrap().iter().sum();
+            let v: u64 = cur_lat_1ms.get(i as u32).unwrap().iter().sum();
             lat_1ms[i] = cmp::max(v - last_lat_1ms[i], 0);
             last_lat_1ms[i] = v;
 
-            let v: u64 = cur_lat_10us.get(i as i32).unwrap().iter().sum();
+            let v: u64 = cur_lat_10us.get(i as u32).unwrap().iter().sum();
             lat_10us[i] = cmp::max(v - last_lat_10us[i], 0);
             last_lat_10us[i] = v;
 

--- a/redbpf-probes/src/net.rs
+++ b/redbpf-probes/src/net.rs
@@ -161,11 +161,7 @@ where
         unsafe {
             let base: *const c_void = match self.transport()? {
                 TCP(hdr) => {
-                    let mut addr = hdr as usize + mem::size_of::<tcphdr>();
-                    let data_offset = (*hdr).doff();
-                    if data_offset > 5 {
-                        addr += ((data_offset - 5) * 4) as usize;
-                    }
+                    let addr = hdr as usize + ((*hdr).doff() * 4) as usize;
                     self.ptr_at(addr)
                 }
                 UDP(hdr) => self.ptr_after(hdr),

--- a/redbpf-tools/probes/src/iotop/main.rs
+++ b/redbpf-tools/probes/src/iotop/main.rs
@@ -37,7 +37,7 @@ fn blk_mq_start_request(regs: Registers) {
 }
 
 #[kprobe]
-fn blk_account_io_completion(regs: Registers) {
+fn blk_account_io_done(regs: Registers) {
     let _ = do_complete(regs);
 }
 

--- a/redbpf-tools/src/bin/redbpf-tcp-knock.rs
+++ b/redbpf-tools/src/bin/redbpf-tcp-knock.rs
@@ -19,7 +19,7 @@ use probes::knock::{Connection, KnockAttempt, PortSequence, MAX_SEQ_LEN};
 
 fn main() {
     if unsafe { libc::getuid() } != 0 {
-        println!("redbpf-knock-knock: You must be root to use eBPF!");
+        println!("redbpf-tcp-knock: You must be root to use eBPF!");
         process::exit(-1);
     }
 


### PR DESCRIPTION
The kernel function "blk_account_io_completion" is not available anymore as attach point of Kprobe as of kernel version 5.8.0, use "blk_account_io_done" instead, see more details in https://github.com/iovisor/bcc/pull/3008
And fix some typos.