### PR TITLE
Improve kernel tree handling to support NixOS

### DIFF
--- a/bpf-sys/src/headers.rs
+++ b/bpf-sys/src/headers.rs
@@ -7,12 +7,20 @@
 
 use crate::uname;
 
-use std::{env,
-	  fmt::{Display, self},
-	  error::Error,
-	  path::{Path, PathBuf},
-	  str::FromStr,
-	  process::Command};
+use std::{
+    env,
+    error::Error,
+    fmt::{self, Display},
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
+
+const KCONFIG: &'static str = "include/linux/kconfig.h";
+const VERSION_H: &'static str = "include/generated/uapi/linux/version.h";
+const LIB_MODULES: &'static str = "/lib/modules";
+const ENV_SOURCE_PATH: &'static str = "KERNEL_SOURCE";
+const ENV_SOURCE_VERSION: &'static str = "KERNEL_VERSION";
 
 #[derive(Debug)]
 pub enum HeadersError {
@@ -27,13 +35,13 @@ impl Error for HeadersError {}
 
 struct KernelHeaders {
     source: PathBuf,
-    build: PathBuf
+    build: PathBuf,
 }
 
 pub struct KernelVersion {
     pub version: u8,
     pub patchlevel: u8,
-    pub sublevel: u8
+    pub sublevel: u8,
 }
 
 pub fn prefix_kernel_headers(headers: &[&str]) -> Option<Vec<String>> {
@@ -54,81 +62,93 @@ pub fn prefix_kernel_headers(headers: &[&str]) -> Option<Vec<String>> {
 }
 
 pub fn running_kernel_version() -> Option<String> {
-    env::var("KERNEL_VERSION").ok().or_else(|| {
-	uname::uname().ok().map(|u| {
-            uname::to_str(&u.release).to_string()
-	})
+    env::var(ENV_SOURCE_VERSION).ok().or_else(|| {
+        uname::uname()
+            .ok()
+            .map(|u| uname::to_str(&u.release).to_string())
     })
 }
 
 pub fn build_kernel_version() -> Result<KernelVersion, Box<dyn Error>> {
     let KernelHeaders { source: _, build } = kernel_headers_path()?;
     let make_db = Command::new("make")
-                          .arg("-qp")
-                          .arg("-f")
-                          .arg(build.join("Makefile"))
-                          .output()?;
+        .arg("-qp")
+        .arg("-f")
+        .arg(build.join("Makefile"))
+        .output()?;
     let reader = String::from_utf8(make_db.stdout)?;
 
     let mut version = None::<u8>;
     let mut patchlevel = None::<u8>;
     let mut sublevel = None::<u8>;
-	
-    for line in reader.lines() {
-	let mut var = line.split(" = ");
-	match var.next() {
-	    Some("VERSION") => version = var.next().map(u8::from_str).transpose()?,
-	    Some("PATCHLEVEL") => patchlevel = var.next().map(u8::from_str).transpose()?,
-	    Some("SUBLEVEL") => sublevel = var.next().map(u8::from_str).transpose()?,
-	    _ => continue
-	}
 
-	if version.is_some() && patchlevel.is_some() && sublevel.is_some() {
-	    break;
-	}
+    for line in reader.lines() {
+        let mut var = line.split(" = ");
+        match var.next().map(|s| s.trim()) {
+            Some("VERSION") => version = var.next().map(u8::from_str).transpose()?,
+            Some("PATCHLEVEL") => patchlevel = var.next().map(u8::from_str).transpose()?,
+            Some("SUBLEVEL") => sublevel = var.next().map(u8::from_str).transpose()?,
+            _ => continue,
+        }
+
+        if version.is_some() && patchlevel.is_some() && sublevel.is_some() {
+            break;
+        }
     }
 
     Ok(KernelVersion {
-	version: version.unwrap(),
-	patchlevel: patchlevel.unwrap(),
-	sublevel: sublevel.unwrap()
+        version: version.unwrap(),
+        patchlevel: patchlevel.unwrap(),
+        sublevel: sublevel.unwrap(),
     })
 }
 
 fn kernel_headers_path() -> Result<KernelHeaders, HeadersError> {
-    env::var("KERNEL_SOURCE")
-    .ok()
-    .map(|s| {
-        let path = PathBuf::from(s);
-        KernelHeaders {
-            source: path.clone(),
-            build: path
-        }
-    })
-    .or_else(lib_modules_kernel_headers)
-    .ok_or(HeadersError::NotFound)
+    let source_path = env::var(ENV_SOURCE_PATH).ok().map(PathBuf::from);
+    let split_source_path = source_path.clone().and_then(split_kernel_headers);
+
+    if split_source_path.is_some() {
+        return Ok(split_source_path.unwrap());
+    }
+
+    source_path
+        .and_then(|s| {
+            let path = PathBuf::from(s);
+
+            if path.join(KCONFIG).is_file() {
+                Some(KernelHeaders {
+                    source: path.clone(),
+                    build: path,
+                })
+            } else {
+                None
+            }
+        })
+        .or_else(lib_modules_kernel_headers)
+        .ok_or(HeadersError::NotFound)
 }
 
 fn lib_modules_kernel_headers() -> Option<KernelHeaders> {
-    if let Some(version) = running_kernel_version() {
-        let path = Path::new("/lib/modules").join(version);
-        let mut build = path.join("build");
-        let source = path.join("source");
-        let kconfig = "include/linux/kconfig.h";
-        let source = match (source.join(kconfig).is_file(), build.join(kconfig).is_file()) {
-            (true, _) => source,
-            (false, true) => build.clone(),
-            _ => return None
-        };
-        if !build.join("include/generated/uapi/linux/version.h").is_file() {
-            build = source.clone()
-        };
-
-        return Some(KernelHeaders {
-            source,
-            build
-        });
+    match running_kernel_version() {
+        Some(version) => split_kernel_headers(Path::new(LIB_MODULES).join(version)),
+        None => None,
     }
+}
 
-    None
+fn split_kernel_headers(path: PathBuf) -> Option<KernelHeaders> {
+    let mut build = path.join("build");
+    let source = path.join("source");
+    let source = match (
+        source.join(KCONFIG).is_file(),
+        build.join(KCONFIG).is_file(),
+    ) {
+        (true, _) => source,
+        (false, true) => build.clone(),
+        _ => return None,
+    };
+    if !build.join(VERSION_H).is_file() {
+        build = source.clone()
+    };
+
+    Some(KernelHeaders { source, build })
 }


### PR DESCRIPTION
This must remain backwards compatible while also making the trees we accept from the `KERNEL_SOURCE` environment variable more versatile. This patchset allows building on NixOS.