### PR TITLE
Add map pin

### DIFF
--- a/examples/example-userspace/build.rs
+++ b/examples/example-userspace/build.rs
@@ -17,4 +17,5 @@ fn main() {
         .for_each(|file| {
             println!("cargo:rerun-if-changed={}", file);
         });
+    println!("cargo:rerun-if-changed=../example-probes/Cargo.toml");
 }

--- a/examples/example-userspace/examples/echo.rs
+++ b/examples/example-userspace/examples/echo.rs
@@ -77,13 +77,13 @@ async fn main() {
         let mut echo_sockmap =
             SockMap::new(loaded.map("echo_sockmap").expect("sockmap not found")).unwrap();
         loaded
-            .stream_parser()
+            .stream_parsers()
             .next()
             .unwrap()
             .attach_sockmap(&echo_sockmap)
             .expect("Attaching sockmap failed");
         loaded
-            .stream_verdict()
+            .stream_verdicts()
             .next()
             .unwrap()
             .attach_sockmap(&echo_sockmap)

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -47,7 +47,8 @@ fn rerun_if_changed_dir(dir: &str) {
 }
 
 fn main() {
-    rerun_if_changed_dir("include");
+    rerun_if_changed_dir("../include");
+    rerun_if_changed_dir("../bpf-sys/libbpf/src");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let types = ["pt_regs", "s32", "bpf_.*"];

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -741,6 +741,10 @@ impl Module {
         self.programs.iter().find(|p| p.name() == name)
     }
 
+    pub fn program_mut(&mut self, name: &str) -> Option<&mut Program> {
+        self.programs.iter_mut().find(|p| p.name() == name)
+    }
+
     pub fn kprobes(&self) -> impl Iterator<Item = &KProbe> {
         use Program::*;
         self.programs.iter().filter_map(|prog| match prog {
@@ -755,6 +759,10 @@ impl Module {
             KProbe(p) | KRetProbe(p) => Some(p),
             _ => None,
         })
+    }
+
+    pub fn kprobe_mut(&mut self, name: &str) -> Option<&mut KProbe> {
+        self.kprobes_mut().find(|p| p.common.name == name)
     }
 
     pub fn uprobes(&self) -> impl Iterator<Item = &UProbe> {
@@ -773,6 +781,10 @@ impl Module {
         })
     }
 
+    pub fn uprobe_mut(&mut self, name: &str) -> Option<&mut UProbe> {
+        self.uprobes_mut().find(|p| p.common.name == name)
+    }
+
     pub fn xdps(&self) -> impl Iterator<Item = &XDP> {
         use Program::*;
         self.programs.iter().filter_map(|prog| match prog {
@@ -787,6 +799,10 @@ impl Module {
             XDP(p) => Some(p),
             _ => None,
         })
+    }
+
+    pub fn xdp_mut(&mut self, name: &str) -> Option<&mut XDP> {
+        self.xdps_mut().find(|p| p.common.name == name)
     }
 
     pub fn socket_filters(&self) -> impl Iterator<Item = &SocketFilter> {
@@ -805,6 +821,10 @@ impl Module {
         })
     }
 
+    pub fn socket_filter_mut(&mut self, name: &str) -> Option<&mut SocketFilter> {
+        self.socket_filters_mut().find(|p| p.common.name == name)
+    }
+
     pub fn trace_points(&self) -> impl Iterator<Item = &TracePoint> {
         use Program::*;
         self.programs.iter().filter_map(|prog| match prog {
@@ -821,7 +841,11 @@ impl Module {
         })
     }
 
-    pub fn stream_parser(&self) -> impl Iterator<Item = &StreamParser> {
+    pub fn trace_point_mut(&mut self, name: &str) -> Option<&mut TracePoint> {
+        self.trace_points_mut().find(|p| p.common.name == name)
+    }
+
+    pub fn stream_parsers(&self) -> impl Iterator<Item = &StreamParser> {
         use Program::*;
         self.programs.iter().filter_map(|prog| match prog {
             StreamParser(p) => Some(p),
@@ -837,7 +861,11 @@ impl Module {
         })
     }
 
-    pub fn stream_verdict(&self) -> impl Iterator<Item = &StreamVerdict> {
+    pub fn stream_parser_mut(&mut self, name: &str) -> Option<&mut StreamParser> {
+        self.stream_parsers_mut().find(|p| p.common.name == name)
+    }
+
+    pub fn stream_verdicts(&self) -> impl Iterator<Item = &StreamVerdict> {
         use Program::*;
         self.programs.iter().filter_map(|prog| match prog {
             StreamVerdict(p) => Some(p),

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -829,7 +829,7 @@ impl Module {
         })
     }
 
-    pub fn stream_parser_mut(&mut self) -> impl Iterator<Item = &mut StreamParser> {
+    pub fn stream_parsers_mut(&mut self) -> impl Iterator<Item = &mut StreamParser> {
         use Program::*;
         self.programs.iter_mut().filter_map(|prog| match prog {
             StreamParser(p) => Some(p),
@@ -845,12 +845,16 @@ impl Module {
         })
     }
 
-    pub fn stream_verdict_mut(&mut self) -> impl Iterator<Item = &mut StreamVerdict> {
+    pub fn stream_verdicts_mut(&mut self) -> impl Iterator<Item = &mut StreamVerdict> {
         use Program::*;
         self.programs.iter_mut().filter_map(|prog| match prog {
             StreamVerdict(p) => Some(p),
             _ => None,
         })
+    }
+
+    pub fn stream_verdict_mut(&mut self, name: &str) -> Option<&mut StreamVerdict> {
+        self.stream_verdicts_mut().find(|p| p.common.name == name)
     }
 }
 
@@ -1401,7 +1405,7 @@ impl StreamParser {
     ///
     /// let loaded = Loader::load(b"echo.elf").expect("error loading BPF program");
     /// let mut echo_sockmap = SockMap::new(loaded.map("echo_sockmap").expect("sockmap not found")).unwrap();
-    /// loaded.stream_parser().next().unwrap().attach_sockmap(&echo_sockmap).expect("Attaching sockmap failed");
+    /// loaded.stream_parsers().next().unwrap().attach_sockmap(&echo_sockmap).expect("Attaching sockmap failed");
     /// ```
     pub fn attach_sockmap(&self, sock_map: &SockMap) -> Result<()> {
         let attach_fd = sock_map.base.fd;
@@ -1432,7 +1436,7 @@ impl StreamVerdict {
     ///
     /// let loaded = Loader::load(b"echo.elf").expect("error loading BPF program");
     /// let mut echo_sockmap = SockMap::new(loaded.map("echo_sockmap").expect("sockmap not found")).unwrap();
-    /// loaded.stream_verdict().next().unwrap().attach_sockmap(&echo_sockmap).expect("Attaching sockmap failed");
+    /// loaded.stream_verdicts().next().unwrap().attach_sockmap(&echo_sockmap).expect("Attaching sockmap failed");
     /// ```
     pub fn attach_sockmap(&self, sock_map: &SockMap) -> Result<()> {
         let attach_fd = sock_map.base.fd;

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -108,35 +108,63 @@ impl Loaded {
         self.module.program(name)
     }
 
+    pub fn program_mut(&mut self, name: &str) -> Option<&mut Program> {
+        self.module.program_mut(name)
+    }
+
     pub fn kprobes_mut(&mut self) -> impl Iterator<Item = &mut KProbe> {
         self.module.kprobes_mut()
+    }
+
+    pub fn kprobe_mut(&mut self, name: &str) -> Option<&mut KProbe> {
+        self.module.kprobe_mut(name)
     }
 
     pub fn uprobes_mut(&mut self) -> impl Iterator<Item = &mut UProbe> {
         self.module.uprobes_mut()
     }
 
+    pub fn uprobe_mut(&mut self, name: &str) -> Option<&mut UProbe> {
+        self.module.uprobe_mut(name)
+    }
+
     pub fn xdps_mut(&mut self) -> impl Iterator<Item = &mut XDP> {
         self.module.xdps_mut()
+    }
+
+    pub fn xdp_mut(&mut self, name: &str) -> Option<&mut XDP> {
+        self.module.xdp_mut(name)
     }
 
     pub fn socket_filters_mut(&mut self) -> impl Iterator<Item = &mut SocketFilter> {
         self.module.socket_filters_mut()
     }
 
-    pub fn stream_parser(&self) -> impl Iterator<Item = &StreamParser> {
-        self.module.stream_parser()
+    pub fn socket_filter_mut(&mut self, name: &str) -> Option<&mut SocketFilter> {
+        self.module.socket_filter_mut(name)
     }
 
-    pub fn stream_parser_mut(&mut self) -> impl Iterator<Item = &mut StreamParser> {
-        self.module.stream_parser_mut()
+    pub fn stream_parsers(&self) -> impl Iterator<Item = &StreamParser> {
+        self.module.stream_parsers()
     }
 
-    pub fn stream_verdict(&self) -> impl Iterator<Item = &StreamVerdict> {
-        self.module.stream_verdict()
+    pub fn stream_parsers_mut(&mut self) -> impl Iterator<Item = &mut StreamParser> {
+        self.module.stream_parsers_mut()
     }
 
-    pub fn stream_verdict_mut(&mut self) -> impl Iterator<Item = &mut StreamVerdict> {
-        self.module.stream_verdict_mut()
+    pub fn stream_parser_mut(&mut self, name: &str) -> Option<&mut StreamParser> {
+        self.module.stream_parser_mut(name)
+    }
+
+    pub fn stream_verdicts(&self) -> impl Iterator<Item = &StreamVerdict> {
+        self.module.stream_verdicts()
+    }
+
+    pub fn stream_verdicts_mut(&mut self) -> impl Iterator<Item = &mut StreamVerdict> {
+        self.module.stream_verdicts_mut()
+    }
+
+    pub fn stream_verdict_mut(&mut self, name: &str) -> Option<&mut StreamVerdict> {
+        self.module.stream_verdict_mut(name)
     }
 }

--- a/redbpf/src/perf.rs
+++ b/redbpf/src/perf.rs
@@ -93,7 +93,7 @@ unsafe fn open_perf_buffer(pid: i32, cpu: i32, group: RawFd, flags: u32) -> Resu
     }
 }
 
-pub(crate) unsafe fn attach_perf_event(prog_fd: libc::c_int, pfd: libc::c_int) -> Result<()> {
+pub(crate) unsafe fn attach_perf_event(prog_fd: RawFd, pfd: RawFd) -> Result<()> {
     if ioctl(pfd, PERF_EVENT_IOC_SET_BPF, prog_fd) < 0 {
         return Err(Error::IO(io::Error::last_os_error()));
     }
@@ -101,6 +101,14 @@ pub(crate) unsafe fn attach_perf_event(prog_fd: libc::c_int, pfd: libc::c_int) -
     if ioctl(pfd, PERF_EVENT_IOC_ENABLE, 0) < 0 {
         return Err(Error::IO(io::Error::last_os_error()));
     }
+    Ok(())
+}
+
+pub(crate) unsafe fn detach_perf_event(pfd: RawFd) -> Result<()> {
+    if ioctl(pfd, PERF_EVENT_IOC_DISABLE, 0) != 0 {
+        return Err(Error::IO(io::Error::last_os_error()));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
- Add map pinning feature (`Map::pin`, `Map::unpin` and `Map::from_pin_path`)
- Detach perf event and close its RawFd when `KProbe`/`UProbe` is dropped
- Close RawFd of `ProgramData` when it is dropped
- Close RawFd of `Map` when it is dropped
- Add accessors to `Loaded` and `Module` to get a reference of structure by name
- Rename `Loaded::stream_parser` to `Loaded::stream_parsers` (plural)
- Fix trivial bug of build script