### PR TITLE
Use `geteuid` instead of `getuid` for privilege checks

### DIFF
--- a/examples/example-userspace/examples/biolatpcts.rs
+++ b/examples/example-userspace/examples/biolatpcts.rs
@@ -66,7 +66,7 @@ fn calc_lat_pct(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ! {
-    if unsafe { libc::getuid() != 0 } {
+    if unsafe { libc::geteuid() != 0 } {
         eprintln!("You must be root to use eBPF!");
         std::process::exit(1);
     }

--- a/examples/example-userspace/examples/echo.rs
+++ b/examples/example-userspace/examples/echo.rs
@@ -21,7 +21,7 @@ enum Command {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    if unsafe { libc::getuid() != 0 } {
+    if unsafe { libc::geteuid() != 0 } {
         eprintln!("You must be root to use eBPF!");
         process::exit(1);
     }

--- a/examples/example-userspace/examples/mallocstacks.rs
+++ b/examples/example-userspace/examples/mallocstacks.rs
@@ -60,7 +60,7 @@ fn start_perf_event_handler(mut loaded: Loaded, acc: Acc) {
 }
 
 fn main() {
-    if unsafe { libc::getuid() } != 0 {
+    if unsafe { libc::geteuid() } != 0 {
         eprintln!("You must be root to use eBPF!");
         process::exit(1);
     }

--- a/examples/example-userspace/examples/tcp-lifetime.rs
+++ b/examples/example-userspace/examples/tcp-lifetime.rs
@@ -25,7 +25,7 @@ use probes::tcp_lifetime::{SocketAddr, TCPLifetime};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    if unsafe { libc::getuid() != 0 } {
+    if unsafe { libc::geteuid() != 0 } {
         eprintln!("You must be root to use eBPF!");
         process::exit(1);
     }

--- a/examples/example-userspace/examples/vfsreadlat.rs
+++ b/examples/example-userspace/examples/vfsreadlat.rs
@@ -72,7 +72,7 @@ fn main() {
         .finish();
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    if unsafe { libc::getuid() } != 0 {
+    if unsafe { libc::geteuid() } != 0 {
         error!("You must be root to use eBPF!");
         process::exit(1);
     }

--- a/redbpf-tools/src/bin/redbpf-iotop.rs
+++ b/redbpf-tools/src/bin/redbpf-iotop.rs
@@ -20,7 +20,7 @@ use tokio::time::sleep;
 use probes::iotop::{Counter, CounterKey};
 
 fn main() {
-    if unsafe { libc::getuid() } != 0 {
+    if unsafe { libc::geteuid() } != 0 {
         println!("redbpf-iotop: You must be root to use eBPF!");
         process::exit(-1);
     }

--- a/redbpf-tools/src/bin/redbpf-tcp-knock.rs
+++ b/redbpf-tools/src/bin/redbpf-tcp-knock.rs
@@ -18,7 +18,7 @@ use tokio::signal;
 use probes::knock::{Connection, KnockAttempt, PortSequence, MAX_SEQ_LEN};
 
 fn main() {
-    if unsafe { libc::getuid() } != 0 {
+    if unsafe { libc::geteuid() } != 0 {
         println!("redbpf-tcp-knock: You must be root to use eBPF!");
         process::exit(-1);
     }


### PR DESCRIPTION
Privilege boundary enforcement in the kernel relies on the *effective* user ID, so userspace code preparing to invoke privileged kernel functionality should always check for the eUID.

This matters especially for `setuid`, which previously was not working with the RedBPF tools:

```
$ sudo chown root redbpf-iotop
$ sudo chmod ug+s redbpf-iotop
$ ./redbpf-iotop
redbpf-iotop: You must be root to use eBPF!
```

With this change, it works as expected, and correctly recognizes that the effective privileges are that of the root user.
