### PR TITLE
Share maps between independent BPF programs

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -43,3 +43,13 @@ required-features = ["probes"]
 name = "biolatpcts"
 path = "src/biolatpcts/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "sharemap1"
+path = "src/sharemap1/main.rs"
+required-features = ["probes"]
+
+[[bin]]
+name = "sharemap2"
+path = "src/sharemap2/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/biolatpcts/main.rs
+++ b/examples/example-probes/src/biolatpcts/main.rs
@@ -7,8 +7,6 @@
 #![no_std]
 #![no_main]
 use core::cmp;
-use core::mem;
-use core::ptr;
 
 use redbpf_probes::kprobe::prelude::*;
 
@@ -20,13 +18,13 @@ use example_probes::bindings::{request, NSEC_PER_MSEC, NSEC_PER_USEC};
 
 program!(0xFFFFFFFE, "GPL");
 
-#[map("lat_100ms")]
+#[map(link_section = "maps/lat_100ms")]
 static mut LAT_100MS: PerCpuArray<u64> = PerCpuArray::with_max_entries(100);
 
-#[map("lat_1ms")]
+#[map(link_section = "maps/lat_1ms")]
 static mut LAT_1MS: PerCpuArray<u64> = PerCpuArray::with_max_entries(100);
 
-#[map("lat_10us")]
+#[map(link_section = "maps/lat_10us")]
 static mut LAT_10US: PerCpuArray<u64> = PerCpuArray::with_max_entries(100);
 
 #[kprobe("blk_account_io_done")]
@@ -42,7 +40,7 @@ fn blk_account_io_done(regs: Registers) {
     let slot = cmp::min(dur / (100 * NSEC_PER_MSEC) as u64, 99);
     unsafe {
         match LAT_100MS.get_mut(slot as u32) {
-            Some(mut val) => *val += 1,
+            Some(val) => *val += 1,
             _ => (),
         }
     }
@@ -53,7 +51,7 @@ fn blk_account_io_done(regs: Registers) {
     let slot = cmp::min(dur / NSEC_PER_MSEC as u64, 99);
     unsafe {
         match LAT_1MS.get_mut(slot as u32) {
-            Some(mut val) => *val += 1,
+            Some(val) => *val += 1,
             _ => (),
         }
     }
@@ -64,7 +62,7 @@ fn blk_account_io_done(regs: Registers) {
     let slot = cmp::min(dur / (10 * NSEC_PER_USEC) as u64, 99);
     unsafe {
         match LAT_10US.get_mut(slot as u32) {
-            Some(mut val) => *val += 1,
+            Some(val) => *val += 1,
             _ => (),
         }
     }

--- a/examples/example-probes/src/sharemap1/main.rs
+++ b/examples/example-probes/src/sharemap1/main.rs
@@ -1,0 +1,15 @@
+#![no_std]
+#![no_main]
+use redbpf_probes::kprobe::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map(link_section = "maps/sharedmap")]
+static mut CLONE_COUNT: Array<u64> = Array::with_max_entries(1);
+
+#[kprobe]
+fn sys_clone(_: Registers) {
+    unsafe {
+        *CLONE_COUNT.get_mut(0).unwrap() += 1;
+    }
+}

--- a/examples/example-probes/src/sharemap2/main.rs
+++ b/examples/example-probes/src/sharemap2/main.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+use redbpf_probes::kprobe::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map(link_section = "maps/sharedmap")]
+static mut SOME_COUNT: Array<u64> = Array::with_max_entries(1);
+
+#[kprobe]
+fn sys_exit(_: Registers) {
+    unsafe {
+        let cnt = SOME_COUNT.get_mut(0).unwrap();
+        if cnt > &mut 1000 {
+            *cnt = 0;
+        }
+    }
+}

--- a/examples/example-userspace/examples/sharemap1.rs
+++ b/examples/example-userspace/examples/sharemap1.rs
@@ -1,0 +1,68 @@
+/// This example is paired with sharemap2 example. The purpose of sharemap1
+/// and sharemap2 is to show how to share maps between independent BPF
+/// programs. First, sharemap1 creates a map and pins it to file. And then
+/// sharemap2 loads the map from the pin file.
+///
+/// 4 programs will share one map. 4 programs consists of the following:
+/// 1. a BPF program in kernel space of sharemap1
+/// 2. a userspace program of sharemap1
+/// 3. a BPF program in kernel space of sharemap2
+/// 4. a userspace program of sharemap2
+use redbpf::load::Loader;
+use redbpf::Array;
+use std::process;
+use std::time::Duration;
+use tokio::signal::ctrl_c;
+use tokio::time::sleep;
+use tracing::{debug, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const PIN_FILE: &str = "/sys/fs/bpf/sharedmap";
+const MAP_NAME: &str = "sharedmap";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::geteuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let mut loaded = Loader::load(probe_code()).unwrap();
+    loaded
+        .map_mut(MAP_NAME)
+        .expect("map not found")
+        .pin(PIN_FILE)
+        .expect("error on pinning");
+    debug!("attach_kprobe on sys_clone");
+    loaded
+        .kprobe_mut("sys_clone")
+        .expect("sys_clone kprobe not found")
+        .attach_kprobe("__x64_sys_clone", 0)
+        .expect("error on attach_kprobe");
+    let arr = Array::<u64>::new(loaded.map_mut(MAP_NAME).unwrap()).expect("error on Array::new");
+    loop {
+        println!("sharemap1 counter: {}", arr.get(0).unwrap());
+        tokio::select! {
+            _ = sleep(Duration::from_secs(1)) => {}
+            _ = ctrl_c() => {
+                break;
+            }
+        }
+    }
+    loaded
+        .map_mut(MAP_NAME)
+        .unwrap()
+        .unpin()
+        .expect("error on unpin");
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/sharemap1/sharemap1.elf"
+    ))
+}

--- a/examples/example-userspace/examples/sharemap2.rs
+++ b/examples/example-userspace/examples/sharemap2.rs
@@ -1,0 +1,75 @@
+/// This example is paired with sharemap1 example. The purpose of sharemap1
+/// and sharemap2 is to show how to share maps between independent BPF
+/// programs. First, sharemap1 creates a map and pins it to file. And then
+/// sharemap2 loads the map from the pin file.
+///
+/// 4 programs will share one map. 4 programs consists of the following:
+/// 1. a BPF program in kernel space of sharemap1
+/// 2. a userspace program of sharemap1
+/// 3. a BPF program in kernel space of sharemap2
+/// 4. a userspace program of sharemap2
+///
+/// The instruction that the sharemap2 loads a map from the pin file which was
+/// created by sharemap1 is defined at example-probes/src/sharemap2/main.rs. It
+/// utilizes `redbpf::Map::from_pin_file` and
+/// `redbpf::ModuleBuilder::replace_map`.
+use redbpf::{Array, Map, ModuleBuilder};
+use std::process;
+use std::time::Duration;
+use tokio::signal::ctrl_c;
+use tokio::time::sleep;
+use tracing::{error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const MAP_NAME: &str = "sharedmap";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::geteuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let mut builder = ModuleBuilder::parse(probe_code()).expect("error on ModuleBuilder::parse");
+    builder
+        .replace_map(
+            MAP_NAME,
+            Map::from_pin_file("/sys/fs/bpf/sharedmap").expect("error on Map::from_pin_file"),
+        )
+        .expect("error on replace_map");
+    let mut module = builder
+        .to_module()
+        .expect("error on ModuleBuilder::to_module");
+
+    for prog in module.programs.iter_mut() {
+        prog.load(module.version, module.license.clone())
+            .expect("error on Program::load");
+    }
+    module
+        .kprobe_mut("sys_exit")
+        .expect("sys_exit kprobe not found")
+        .attach_kprobe("__x64_sys_exit", 0)
+        .expect("error on attach_kprobe");
+    let arr = Array::<u64>::new(module.map(MAP_NAME).expect("map not found"))
+        .expect("error on Array::new");
+    loop {
+        println!("sharemap2 counter: {}", arr.get(0).unwrap());
+        tokio::select! {
+            _ = sleep(Duration::from_secs(1)) => {}
+            _ = ctrl_c() => {
+                break;
+            }
+        }
+    }
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/sharemap2/sharemap2.elf"
+    ))
+}

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bpf-sys = { path = "../bpf-sys", version = "^1.3.0" }
-goblin = "0.2"
+goblin = "0.4"
 zero = "0.1"
 libc = "0.2"
 bindgen = {version = "0.55", default-features = false, features = ["runtime"]}

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -97,11 +97,11 @@ pub struct Loaded {
 
 impl Loaded {
     pub fn map(&self, name: &str) -> Option<&Map> {
-        self.module.maps.iter().find(|m| m.name == name)
+        self.module.map(name)
     }
 
     pub fn map_mut(&mut self, name: &str) -> Option<&mut Map> {
-        self.module.maps.iter_mut().find(|m| m.name == name)
+        self.module.map_mut(name)
     }
 
     pub fn program(&self, name: &str) -> Option<&Program> {


### PR DESCRIPTION
- Add #[map(from_pin_file = "...")] meta into map attribute macro
- Add mapxattr/maps/<item_name> sections only if the new meta is used
- Parse mapxattr/maps/<item_name> sections and let programs share already existing maps
- Add sharemap1/sharemap2 examples
- Fix example probe compile warnings
- Substitute ingraind with foniod