### PR TITLE
Bump LLVM version to 12

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -27,7 +27,7 @@ futures = { version = "0.3", optional = true }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
 libc = {version = "0.2.66", optional = true}
-llvm-sys = { version = "110", optional = true}
+llvm-sys = { version = "120", optional = true}
 syn = { version = "1.0", features = ["full", "visit"], optional = true }
 quote = { version = "1.0", optional = true }
 proc-macro2 = {version = "1.0", optional = true}


### PR DESCRIPTION
This commit 4f45dd15 added by PR #153 incurs build failure if rust version is
1.53 (currently the latest stable version)
> $ cargo build --bin redbpf-iotop
> ... omitted ...
> error: failed to run custom build command for `redbpf-tools v0.1.0 (/home/esrse/opensource/redbpf/redbpf-tools)`
> 
> Caused by:
>   process didn't exit successfully: `/home/esrse/opensource/redbpf/target/debug/build/redbpf-tools-fc73fb264ffefcc9/build-script-build` (exit status: 101)
>   --- stderr
>      Compiling libc v0.2.91
>      Compiling cfg-if v1.0.0
>      Compiling proc-macro2 v1.0.24
>      Compiling unicode-xid v0.2.1
>      Compiling version_check v0.9.3
>      Compiling getrandom v0.2.2
>      Compiling glob v0.3.0
>      Compiling memchr v2.3.4
>      Compiling bitflags v1.2.1
>      Compiling bindgen v0.55.1
>      Compiling regex-syntax v0.6.23
>      Compiling syn v1.0.64
>      Compiling rustc-hash v1.1.0
>      Compiling shlex v0.1.1
>      Compiling lazy_static v1.4.0
>      Compiling lazycell v1.3.0
>      Compiling cfg-if v0.1.10
>      Compiling peeking_take_while v0.1.2
>      Compiling ppv-lite86 v0.2.10
>      Compiling cc v1.0.67
>      Compiling ucd-trie v0.1.3
>      Compiling anyhow v1.0.39     Compiling zero v0.1.2
>      Compiling remove_dir_all v0.5.3
>      Compiling proc-macro-hack v0.5.19
>      Compiling ufmt-write v0.1.0
>      Compiling cty v0.2.1
>      Compiling libloading v0.7.0
>      Compiling nom v5.1.2
>      Compiling pest v2.1.3
>      Compiling clang-sys v1.1.1
>      Compiling quote v1.0.9
>      Compiling rand_core v0.6.2
>      Compiling uuid v0.8.2
>      Compiling semver-parser v0.10.2
>      Compiling rand_chacha v0.3.0
>      Compiling regex v1.4.5
>      Compiling rand v0.8.3
>      Compiling semver v0.11.0
>      Compiling rustc_version v0.3.3
>      Compiling cexpr v0.4.0
>      Compiling tempfile v3.2.0
>      Compiling redbpf-macros v1.3.0 (/home/esrse/opensource/redbpf/redbpf-macros)
>      Compiling ufmt-macros v0.1.1
>      Compiling ufmt v0.1.0
>      Compiling bpf-sys v1.3.0 (/home/esrse/opensource/redbpf/bpf-sys)
>      Compiling cargo-bpf v1.3.0 (/home/esrse/opensource/redbpf/cargo-bpf)
>      Compiling redbpf-probes v1.3.0 (/home/esrse/opensource/redbpf/redbpf-probes)
>      Compiling probes v0.1.0 (/home/esrse/opensource/redbpf/redbpf-tools/probes)
>   warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
> 
>   warning: ignoring --out-dir flag due to -o flag
> 
>   warning: 2 warnings emitted
> 
>       Finished release [optimized] target(s) in 1m 01s
>   thread 'main' panicked at 'couldn't compile probes: Compile("iotop", Some("couldn't process IR file: LLVMParseIRInContext failed: /home/esrse/opensource/redbpf/target/debug/build/redbpf-tools-95c4112c1301900b/out/target/bpf/programs/iotop/iotop-0bf34942edfb2894.bc: error: Invalid record\n"))', redbpf-tools/build.rs:17:6
>   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> 
> 

While I was developing code for PR #153, I had used rust 1.51 and I did not
experience this problem. But it appears after I ran `rustup update` to get rust 1.53.

Problem disappears after bumping up LLVM to 12.
