### PR TITLE
Tc map share

### DIFF
--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -146,7 +146,7 @@ fn build_probe(cargo: &Path, package: &Path, target_dir: &Path, probe: &str) -> 
     })?;
 
     // stripping debug sections is optional process. So don't care its failure.
-    let _ = llvm::strip_debug(target);
+    let _ = llvm::strip_debug(&target);
 
     Ok(())
 }

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -101,8 +101,8 @@ pub unsafe fn compile(input: &Path, output: &Path, bc_output: Option<&Path>) -> 
 /// associated relocation sections. But .BTF related sections are not stripped.
 ///
 /// cf) `llvm_sys::debuginfo::LLVMStripModuleDebugInfo` removes BTF sections so do not call it.
-pub(crate) fn strip_debug(target: impl AsRef<Path>) -> Result<()> {
-    Command::new("llvm-strip")
+pub(crate) fn strip_debug(target: &impl AsRef<Path>) -> Result<()> {
+    Command::new("llvm-strip-12")
         .arg("-g")
         .arg(target.as_ref())
         .status()

--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -55,3 +55,8 @@ required-features = ["probes"]
 name = "sharemap2"
 path = "src/sharemap2/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "tc-map-share"
+path = "src/tc_map_share/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/tc_map_share/main.rs
+++ b/examples/example-probes/src/tc_map_share/main.rs
@@ -1,0 +1,109 @@
+#![no_std]
+#![no_main]
+/// tc map sharing example. This program is loaded by `tc filter add ...`
+/// command which is executed by `cargo run --example tc-map-share <port>...`
+use core::{
+    mem::{self, MaybeUninit},
+    ptr,
+};
+use memoffset::offset_of;
+use redbpf_macros::map;
+use redbpf_probes::tc::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+/// A section name of tc map should be `maps`. You can define up to 64 tc maps
+/// in the section (`tc` sets that constraints).
+///
+/// key = port, value = blocked packet count
+#[map(link_section = "maps")]
+static mut blocked_packets: TcHashMap<u16, u64> =
+    TcHashMap::<u16, u64>::with_max_entries(1024, TcMapPinning::GlobalNamespace);
+
+/// BPF program type is BPF_PROG_TYPE_SCHED_CLS
+#[tc_action]
+fn block_ports(skb: SkBuff) -> TcActionResult {
+    let tcp_hdr_offset = match u32::from_be(unsafe { *skb.skb }.protocol << 16) {
+        ETH_P_IP => {
+            let mut uninit = MaybeUninit::<iphdr>::uninit();
+            if unsafe {
+                bpf_skb_load_bytes(
+                    skb.skb as *const _,
+                    mem::size_of::<ethhdr>() as u32,
+                    uninit.as_mut_ptr() as *mut _,
+                    mem::size_of::<iphdr>() as u32,
+                )
+            } < 0
+            {
+                return Ok(TcAction::Ok);
+            }
+            let ipv4_hdr = unsafe { uninit.assume_init() };
+            if !(ipv4_hdr.version() == 4 && IPPROTO_TCP == ipv4_hdr.protocol as u32) {
+                return Ok(TcAction::Ok);
+            }
+            let iphdr_len = ipv4_hdr.ihl() as usize * 4;
+            mem::size_of::<ethhdr>() + iphdr_len
+        }
+        ETH_P_IPV6 => {
+            // following chain of extension headers is not implemented here
+            let nexthdr =
+                skb.load::<u8>(mem::size_of::<ethhdr>() + offset_of!(ipv6hdr, nexthdr))?;
+            if IPPROTO_TCP != nexthdr as u32 {
+                return Ok(TcAction::Ok);
+            }
+            mem::size_of::<ethhdr>() + mem::size_of::<ipv6hdr>()
+        }
+        _ => return Ok(TcAction::Ok),
+    };
+    let port = skb.load::<u16>(tcp_hdr_offset + offset_of!(tcphdr, dest))?;
+    if let Some(cnt) = unsafe { blocked_packets.get_mut(&port) } {
+        trace_print(b"blocked port: ", port);
+        *cnt += 1;
+        Ok(TcAction::Shot)
+    } else {
+        trace_print(b"passed port: ", port);
+        Ok(TcAction::Ok)
+    }
+}
+
+fn hex_u8(v: u8, buf: &mut [u8]) {
+    let w = v / 0x10;
+    buf[0] = if w < 0xa { w + b'0' } else { w - 0xa + b'a' };
+    let u = v % 0x10;
+    buf[1] = if u < 0xa { u + b'0' } else { u - 0xa + b'a' };
+}
+
+fn hex_bytes(arr: &[u8], buf: &mut [u8]) -> usize {
+    let mut pos = 0;
+    for (i, b) in arr.iter().enumerate() {
+        if i != 0 {
+            buf[pos] = b' ';
+            pos += 1;
+        }
+        hex_u8(*b, &mut buf[pos..pos + 2]);
+        pos += 2;
+    }
+    pos
+}
+
+fn trace_print<T>(msg: &[u8], x: T) {
+    let mut buf = [0u8; 128];
+    let mut pos = 0;
+    for c in msg {
+        buf[pos] = *c;
+        pos += 1;
+    }
+
+    let ptr = &x as *const T as *const usize as usize;
+    let sz = mem::size_of::<T>();
+    let mut arr = [0u8; 64];
+    for i in 0..sz {
+        arr[i] = unsafe { ptr::read((ptr + i) as *const usize as *const u8) };
+    }
+
+    pos += hex_bytes(&arr[..sz], &mut buf[pos..]);
+    buf[pos] = b'\n';
+    pos += 2;
+
+    bpf_trace_printk(&buf[..pos]);
+}

--- a/examples/example-userspace/examples/tc-map-share.rs
+++ b/examples/example-userspace/examples/tc-map-share.rs
@@ -1,0 +1,122 @@
+/// This example demonstrates how to interact with BPF program loaded by tc
+/// utility. A BPF program that is loaded by tc also can get values from or set
+/// values to BPF maps. And tc pins maps to specific paths. Maps are pinned to
+/// `/sys/fs/bpf/tc/globals/<map symbol name>`. In userspace, we can load pinned
+/// BPF maps using `Map::from_pin_file` function. By this method, our userspace
+/// programs are able to interact with BPF programs loaded by tc utility.
+///
+/// Usage: sudo -Es (which cargo) run --example tc-map-share 8080 8081 8082
+///
+/// And try running `nc localhost 8080`. nc will not succeed to connect to 8080
+/// because tc BPF program blocks packets of which port number is 8080
+use redbpf::{HashMap, Map};
+use std::{
+    env, fs,
+    process::{self, Command},
+    time::Duration,
+};
+use tokio::{select, signal::ctrl_c, time::sleep};
+use tracing::{debug, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const TC_BLOCKED_PACKETS_MAP: &str = "/sys/fs/bpf/tc/globals/blocked_packets";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::getuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let ports = env::args()
+        .skip(1)
+        .map(|s| {
+            s.parse::<u16>()
+                .expect(format!("Unable to convert {} to u16", s).as_str())
+        })
+        .collect::<Vec<u16>>();
+    if ports.is_empty() {
+        error!("Specify port numbers to block");
+        process::exit(1);
+    }
+
+    let bpf_elf = concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/tc-map-share/tc-map-share.elf"
+    );
+    // remove .BTF.ext and .eh_frame in order to remove .text
+    // remove .text section because tc filter does not work if .text exists
+    // remove .BTF section because it contains invalid names of BTF types
+    // (currently kernel only allows valid symbol names of C)
+    for sec in &[".BTF.ext", ".eh_frame", ".text", ".BTF"] {
+        if !Command::new("llvm-strip-12")
+            .arg("--no-strip-all")
+            .arg("--remove-section")
+            .arg(sec)
+            .arg(&bpf_elf)
+            .status()
+            .expect("error on running command llvm-strip-12")
+            .success()
+        {
+            error!("error on removing section `{}' using llvm-strip-12", sec);
+            return;
+        }
+    }
+    let new_clsact = Command::new("tc")
+        .args("qdisc add dev lo clsact".split(" "))
+        .status()
+        .expect("error on tc qdisc add")
+        .success();
+
+    debug!("Attaching tc BPF program to `lo' interface as direct action");
+    Command::new("tc")
+        .args("filter add dev lo ingress bpf direct-action".split(" "))
+        .arg("object-file")
+        .arg(bpf_elf)
+        .args("section tc_action/block_ports".split(" "))
+        .status()
+        .expect("error on tc filter add");
+
+    // Load map from pinned file that is just created by tc
+    let map = Map::from_pin_file(TC_BLOCKED_PACKETS_MAP).expect("error on Map::from_pin_file");
+    let blocked_packets = HashMap::<u16, u64>::new(&map).expect("error on HashMap::new");
+
+    // Set port numbers to block
+    // Then port numbers are read by tc BPF program and it will block packets
+    // of which port numbers are found at the `HashMap`.
+    for port in ports {
+        blocked_packets.set(port, 0);
+    }
+
+    println!("Hit Ctrl-C to quit");
+    println!("port => blocked packet count");
+    loop {
+        select! {
+            _ = sleep(Duration::from_secs(1)) => {}
+            _ = ctrl_c() => break
+
+        }
+        for (port, blocked_cnt) in blocked_packets.iter() {
+            println!("{} => {}", port, blocked_cnt);
+        }
+    }
+
+    if new_clsact {
+        let _ = Command::new("tc")
+            .args("qdisc del dev lo clsact".split(" "))
+            .status();
+    } else {
+        let _ = Command::new("tc")
+            .args("filter del dev lo ingress protocol all pref 49152 bpf direct-action".split(" "))
+            .arg("object-file")
+            .arg(bpf_elf)
+            .args("section tc_action/block_ports".split(" "))
+            .status();
+    }
+
+    let _ = fs::remove_file(TC_BLOCKED_PACKETS_MAP);
+}

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -578,11 +578,7 @@ pub fn tc_action(attrs: TokenStream, item: TokenStream) -> TokenStream {
         fn #outer_ident(skb: *const ::redbpf_probes::bindings::__sk_buff) -> i32 {
             let skb = ::redbpf_probes::socket::SkBuff { skb };
             return match #ident(skb) {
-                Ok(::redbpf_probes::tc::TcAction::Ok) => 0,
-                Ok(::redbpf_probes::tc::TcAction::Shot) => 2,
-                Ok(::redbpf_probes::tc::TcAction::Unspec) => -1,
-                Ok(::redbpf_probes::tc::TcAction::Pipe) => 3,
-                Ok(::redbpf_probes::tc::TcAction::Reclassify) => 1,
+                Ok(act) => act as i32,
                 Err(_) => -1
             };
 

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -57,6 +57,7 @@ fn main() {
         "xdp_md",
         "ethhdr",
         "iphdr",
+        "ipv6hdr",
         "tcphdr",
         "udphdr",
         "xdp_action",

--- a/redbpf-probes/src/sockmap/mod.rs
+++ b/redbpf-probes/src/sockmap/mod.rs
@@ -1,3 +1,12 @@
+// Copyright 2021 Junyeong Jeong <rhdxmr@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+/*!
+Sockmap for socket redirection with stream parser and verdict
+*/
 pub mod prelude;
 use crate::socket::SocketError;
 

--- a/redbpf-probes/src/tc/maps.rs
+++ b/redbpf-probes/src/tc/maps.rs
@@ -1,0 +1,190 @@
+// Copyright 2021 Junyeong Jeong <rhdxmr@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+/*!
+eBPF maps for tc
+
+Provide BPF maps similar to
+[`redbpf_probes::maps::HashMap`](../../maps/struct.HashMap.html) but can be
+used only by `tc` BPF programs. So the counter part of
+[`TcHashMap`](struct.TcHashMap.html) for userspace program does not
+exist. However, if [`TcHashMap`](struct.TcHashMap.html) is created with
+[`TcMapPinning::GlobalNamespace`](enum.TcMapPinning.html#variant.GlobalNamespace),
+it is possible for userspace program of `redBPF` to load the pinning file by
+calling
+[`Map::from_pin_file`](../../../redbpf/struct.Map.html#method.from_pin_file). And
+then, the base map can be wrapped by
+[`redbpf::HashMap`](../../../redbpf/struct.HashMap.html).
+*/
+use core::marker::PhantomData;
+use core::mem;
+
+use crate::bindings::*;
+use crate::helpers::*;
+
+/// `bpf_elf_map` struct is defined by tc. It is not required to use the same
+/// name, but it is better to do so.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct bpf_elf_map {
+    type_: u32,
+    size_key: u32,
+    size_value: u32,
+    max_elem: u32,
+    flags: u32,
+    id: u32,
+    pinning: u32,
+}
+
+/// BPF hashmap structure used by `tc` utility
+///
+/// `tc` supports attaching BPF programs to qdisc as direct action. And the
+/// attached BPF programs can use BPF maps. But the internal structure of BPF
+/// maps of `tc` is a bit different from the maps of `redBPF`. So in order to
+/// define BPF maps for `tc` BPF programs, new structure should be used, not
+/// the `HashMap`, `Array` or `PerCpuArray`. To solve this problem `TcHashMap`
+/// is introduced to `redBPF`. It makes BPF maps available to `tc` BPF programs
+/// that is also defined by `#[tc_action]` attribute macro of `redBPF`.
+///
+/// # Example
+/// ```no_run
+/// use redbpf_macros::map;
+/// use redbpf_probes::tc::prelude::*;
+///
+/// // A section name of tc BPF map should be `maps`. You can define up to 64
+/// // maps in the section (`tc` sets that constraints).
+/// //
+/// // key = port, value = blocked packet count
+/// #[map(link_section = "maps")]
+/// static mut blocked_packets: TcHashMap<u16, u64> =
+///     TcHashMap::<u16, u64>::with_max_entries(1024, TcMapPinning::GlobalNamespace);
+/// ```
+pub struct TcHashMap<K, V> {
+    def: bpf_elf_map,
+    _k: PhantomData<K>,
+    _v: PhantomData<V>,
+}
+
+/// A structure representing types of map pinning
+///
+/// Pinning the map is conducted by `tc` utility when an ELF object file is
+/// loaded by `tc filter add ... bpf direct-action object-file <ELF object
+/// file> section <section>` command.
+///
+/// `GlobalNamespace` pins map to a stationary file path
+///
+/// `None` disables map pinning
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum TcMapPinning {
+    /// No sharing, no map pinning. so each tc invocation a new map instance is
+    /// being created.
+    None = 0,
+    /// Map is private and thus shared among various program sections within
+    /// the ELF object. That means a BPF map is pinned to `/sys/fs/bpf/tc/<some
+    /// object id>/<map name>`
+    ObjectNamespace,
+    /// Place the map into a global namespace, so that it can be shared among
+    /// different object files. That means a BPF map is pinned to
+    /// `/sys/fs/bpf/tc/globals/<map name>`.
+    GlobalNamespace,
+}
+
+impl<K, V> TcHashMap<K, V> {
+    /// Creates a map with the specified maximum number of elements and pinning
+    /// type.
+    pub const fn with_max_entries(max_entries: u32, pinning: TcMapPinning) -> Self {
+        Self {
+            def: bpf_elf_map {
+                type_: bpf_map_type_BPF_MAP_TYPE_HASH,
+                size_key: mem::size_of::<K>() as u32,
+                size_value: mem::size_of::<V>() as u32,
+                max_elem: max_entries,
+                flags: 0,
+                id: 0,
+                pinning: pinning as u32,
+            },
+            _k: PhantomData,
+            _v: PhantomData,
+        }
+    }
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// NOTE: `tc` does not support relocation across ELF sections. So do not
+    /// call this method like this `tcmap.get(&714)`. The correct code looks
+    /// like the example below.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redbpf_macros::map;
+    /// # use redbpf_probes::tc::prelude::*;
+    /// # use redbpf_probes::tc::{TcAction, TcActionResult};
+    /// #[map(link_section = "maps")]
+    /// static mut tcmap: TcHashMap<u16, u64> =
+    ///     TcHashMap::<u16, u64>::with_max_entries(1024, TcMapPinning::GlobalNamespace);
+    /// #[tc_action]
+    /// fn tc_bpf_program(skb: SkBuff) -> TcActionResult {
+    ///     let key = 714;
+    ///     // use a reference of a local variable, Luke!
+    ///     let val = unsafe { tcmap.get(&key).unwrap() };
+    ///     Ok(TcAction::Ok)
+    /// }
+    /// ```
+    #[inline]
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        unsafe {
+            let value = bpf_map_lookup_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+            if value.is_null() {
+                None
+            } else {
+                Some(&*(value as *const V))
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        unsafe {
+            let value = bpf_map_lookup_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+            if value.is_null() {
+                None
+            } else {
+                Some(&mut *(value as *mut V))
+            }
+        }
+    }
+
+    /// Set the `value` in the map for `key`
+    #[inline]
+    pub fn set(&mut self, key: &K, value: &V) {
+        unsafe {
+            bpf_map_update_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+                value as *const _ as *const _,
+                BPF_ANY.into(),
+            );
+        }
+    }
+
+    /// Delete the entry indexed by `key`
+    #[inline]
+    pub fn delete(&mut self, key: &K) {
+        unsafe {
+            bpf_map_delete_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+        }
+    }
+}

--- a/redbpf-probes/src/tc/mod.rs
+++ b/redbpf-probes/src/tc/mod.rs
@@ -1,18 +1,42 @@
 use crate::socket::SocketError;
 
 /// Possible actions in tc programs
+///
+/// Allowed return opcodes from BPF programs are listed at
+/// <https://elixir.bootlin.com/linux/v5.13.2/source/net/sched/cls_bpf.c#L65>
+#[repr(i32)]
 pub enum TcAction {
-    /// Terminate the packet processing pipeline and allows the packet to proceed
-    Ok,
-    /// Terminate the packet processing pipeline and drops the packet
-    Shot,
     /// Use the default action configured from `tc`
-    Unspec,
-    /// Iterate to the next action, if available
-    Pipe,
-    /// Terminate the packet processing pipeline and
-    /// start classification from the beginning
+    Unspec = -1,
+    /// Terminate the packet processing pipeline and allows the packet to
+    /// proceed
+    Ok = 0,
+    /// Terminate the packet processing pipeline and start classification from
+    /// the beginning
+    #[deprecated(note = "linux kernel commit `5cf8ca0e` (linux v4.3) removed this from cls_bpf")]
     Reclassify,
+    /// Terminate the packet processing pipeline and drops the packet
+    Shot = 2,
+    /// Iterate to the next action, if available
+    #[deprecated(note = "linux kernel commit `5cf8ca0e` (linux v4.3) removed this from cls_bpf")]
+    Pipe,
+    /// TC_ACT_SHOT will indicate to the kernel that the skb was released
+    /// through kfree_skb() and return NET_XMIT_DROP to the callers for
+    /// immediate feedback, whereas TC_ACT_STOLEN will release the skb through
+    /// consume_skb() and pretend to upper layers that the transmission was
+    /// successful through NET_XMIT_SUCCESS. The perf’s drop monitor which
+    /// records traces of kfree_skb() will therefore also not see any drop
+    /// indications from TC_ACT_STOLEN since its semantics are such that the
+    /// skb has been “consumed” or queued but certainly not “dropped”.
+    /// cf) <https://docs.cilium.io/en/latest/bpf/#tc-traffic-control>
+    Stolen = 4,
+    /// Allow to redirect the skb to the same or another’s device ingress or
+    /// egress path together with the bpf_redirect() helper
+    Redirect = 7,
+    /// For hw path, this means "trap to cpu" and don't further process the
+    /// frame in hardware. For sw path, this is equivalent of `Stolen` - drop
+    /// the skb and act like everything is alright.
+    Trap = 8,
 }
 
 /// Result type for tc action programs.

--- a/redbpf-probes/src/tc/mod.rs
+++ b/redbpf-probes/src/tc/mod.rs
@@ -1,3 +1,43 @@
+// Copyright 2021 Authors of redBPF
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+/*!
+BPF for tc utility
+
+tc supports attaching BPF programs to `clsact` qdisc as a direct action. You
+can write BPF programs and BPF maps using `redBPF`.
+
+# Example
+
+```no_run
+#![no_std]
+#![no_main]
+
+use redbpf_macros::map;
+use redbpf_probes::tc::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map(link_section = "maps")]
+static mut blocked_packets: TcHashMap<u16, u64> =
+    TcHashMap::<u16, u64>::with_max_entries(1024, TcMapPinning::GlobalNamespace);
+
+#[tc_action]
+fn block_ports(skb: SkBuff) -> TcActionResult {
+    // do some stuff ...
+    let port = 714;
+    if let Some(count) = unsafe { blocked_packets.get(&port) } {
+        *count += 1;
+        Ok(TcAction::Shot)
+    } else {
+        Ok(TcAction::Ok)
+    }
+}
+```
+*/
 use crate::socket::SocketError;
 
 /// Possible actions in tc programs

--- a/redbpf-probes/src/tc/mod.rs
+++ b/redbpf-probes/src/tc/mod.rs
@@ -41,10 +41,11 @@ pub enum TcAction {
 
 /// Result type for tc action programs.
 pub type TcActionResult = Result<TcAction, SocketError>;
+pub mod maps;
 
 pub mod prelude {
+    pub use super::maps::*;
     pub use super::*;
-
     pub use crate::bindings::*;
     pub use crate::helpers::*;
     pub use crate::maps::*;

--- a/redbpf/src/btf.rs
+++ b/redbpf/src/btf.rs
@@ -32,6 +32,7 @@ pub(crate) struct BTF {
 
 struct BtfTypeCommon {
     type_: btf_type,
+    #[allow(unused)]
     name_fixed: Option<String>,
     name_raw: String,
 }

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -1553,6 +1553,10 @@ impl<'base, K: Clone, V: Clone> HashMap<'base, K, V> {
         if mem::size_of::<K>() != base.config.key_size as usize
             || mem::size_of::<V>() != base.config.value_size as usize
         {
+            error!(
+                "map definitions (sizes of key and value) of base `Map' and
+            `HashMap' do not match"
+            );
             return Err(Error::Map);
         }
 
@@ -1609,6 +1613,10 @@ impl<'base, T: Clone> Array<'base, T> {
         if mem::size_of::<T>() != base.config.value_size as usize
             || bpf_map_type_BPF_MAP_TYPE_ARRAY != base.config.type_
         {
+            error!(
+                "map definitions (size of value, map type) of base `Map' and
+            `Array' do not match"
+            );
             return Err(Error::Map);
         }
 
@@ -1720,6 +1728,10 @@ impl<'base, T: Clone> PerCpuArray<'base, T> {
         if mem::size_of::<T>() != base.config.value_size as usize
             || bpf_map_type_BPF_MAP_TYPE_PERCPU_ARRAY != base.config.type_
         {
+            error!(
+                "map definitions (size of value, map type) of base `Map' and
+            `PerCpuArray' do not match"
+            );
             return Err(Error::Map);
         }
 
@@ -1816,6 +1828,10 @@ impl<'base> ProgramArray<'base> {
         if mem::size_of::<u32>() != base.config.key_size as usize
             || mem::size_of::<RawFd>() != base.config.value_size as usize
         {
+            error!(
+                "map definitions (sizes of key and value) of base `Map' and
+            `ProgramArray' do not match"
+            );
             return Err(Error::Map);
         }
 


### PR DESCRIPTION
- Fix `TcAction` enum
- Add tc example that shows how to share a map between tc BPF program and redBPF userspace program