### PR TITLE
Fix dependency versions at Cargo.toml of examples

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -6,12 +6,12 @@ repository = "https://github.com/foniod/redbpf"
 authors = ["Peter Parkanyi <p@symmetree.dev>", "Junyeong Jeong <rhdxmr@gmail.com>"]
 
 [build-dependencies]
-cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
+cargo-bpf = { version = "*", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = { version = "", path = "../../redbpf-macros" }
-redbpf-probes = { version = "", path = "../../redbpf-probes" }
+redbpf-macros = { version = "*", path = "../../redbpf-macros" }
+redbpf-probes = { version = "*", path = "../../redbpf-probes" }
 memoffset = "0.6.1"
 
 [features]

--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 repository = "https://github.com/foniod/redbpf"
 
 [build-dependencies]
-cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { version = "*", path = "../../cargo-bpf", default-features = false, features = ["build"] }
 
 [dependencies]
 probes = { path = "../example-probes", package = "example-probes" }
 libc = "0.2"
 tokio = { version = "^1.0.1", features = ["rt", "signal", "time", "io-util", "net", "sync"] }
-redbpf = { version = "", path = "../../redbpf", features = ["load"] }
+redbpf = { version = "*", path = "../../redbpf", features = ["load"] }
 futures = "0.3"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"


### PR DESCRIPTION
Since cargo v1.54, invalid syntax for version requirements is rejected
cf)
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-154-2021-07-29
https://github.com/rust-lang/cargo/pull/9508

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>