### PR TITLE
Add llvm11 and llvm12 feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,27 @@ The redbpf project is a collection of tools and libraries to build eBPF
 programs using Rust. It includes:
 
 - [redbpf](https://foniod.org/api/redbpf/) - a user space library that can be
-  used to load eBPF programs
+  used to load eBPF programs or access eBPF maps.
 
 - [redbpf-probes](https://foniod.org/api/redbpf_probes/) - an idiomatic Rust
   API to write eBPF programs that can be loaded by the linux kernel
 
 - [redbpf-macros](https://foniod.org/api/redbpf_macros/) - companion crate to
   `redbpf-probes` which provides convenient procedural macros useful when
-  writing eBPF programs
+  writing eBPF programs. For example, `#[map]` for defining a map, `#[kprobe]`
+  for defining a BPF program that can be attached to kernel functions.
 
 - [cargo-bpf](https://foniod.org/api/cargo_bpf/) - a cargo subcommand for
   creating, building and debugging eBPF programs
 
 # Requirements
 
-In order to use redbpf you need LLVM 11 and the headers for the kernel you want
-to target.
+In order to use redBPF, you need
+- LLVM 12 or LLVM 11
+- either the Linux kernel's headers or `vmlinux`, you want to target
+
+LLVM 12 is used as a default when compiling BPF programs, but you can use LLVM
+11 as follows: `cargo build --no-default-features --features llvm11`
 
 ## Linux kernel
 
@@ -41,23 +46,28 @@ long as you run `make prepare` first.
 On Debian, Ubuntu and derivatives you can install the dependencies running:
 
 	sudo apt-get -y install build-essential zlib1g-dev \
-			llvm-11-dev libclang-11-dev linux-headers-$(uname -r)
+			llvm-12-dev libclang-12-dev linux-headers-$(uname -r)
 
-If your distribution doesn't have LLVM 11, you can add the [official LLVM
+If your distribution doesn't have LLVM 12, you can add the [official LLVM
 APT repository](https://apt.llvm.org) to your `sources.list`.
 
 ## Installing dependencies on RPM based distributions
 
-First ensure that your distro includes LLVM 11:
+First ensure that your distro includes LLVM 12:
 
 	yum info llvm-devel | grep Version
-	Version      : 11.0.0
+	Version      : 12.0.0
 
-If you don't have vesion 11, you can get it from the Fedora 33 repository.
+If you don't have vesion 12, you can get it from the Fedora 34 repository.
 
 Then install the dependencies running:
 
 	yum install clang llvm-devel zlib-devel kernel-devel
+
+## Build images
+
+You can refer to `Dockerfile`s that are ready for building redBPF and foniod:
+[build-images](https://github.com/foniod/build-images)
 
 # Getting started
 

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -27,7 +27,6 @@ futures = { version = "0.3", optional = true }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
 libc = {version = "0.2.66", optional = true}
-llvm-sys = { version = "120", optional = true}
 syn = { version = "1.0", features = ["full", "visit"], optional = true }
 quote = { version = "1.0", optional = true }
 proc-macro2 = {version = "1.0", optional = true}
@@ -35,10 +34,16 @@ tempfile = { version = "3.1", optional = true}
 lazy_static = "1.0"
 glob = "0.3"
 anyhow = "1.0"
+llvm-sys-110 = { version = "110", optional = true, package = "llvm-sys" }
+llvm-sys-120 = { version = "120", optional = true, package = "llvm-sys" }
+cfg-if = "1.0"
+rustversion = "1.0"
 
 [features]
-default = ["command-line"]
+default = ["command-line", "llvm12"]
 bindings = ["bpf-sys", "bindgen", "syn", "quote", "proc-macro2", "tempfile"]
-build = ["bindings", "libc", "toml_edit", "llvm-sys"]
+build = ["bindings", "libc", "toml_edit"]
+llvm11 = ["llvm-sys-110"]
+llvm12 = ["llvm-sys-120"]
 build-c = []
 command-line = ["build", "clap", "redbpf/load", "futures", "tokio", "hexdump"]

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -1,3 +1,15 @@
+#[cfg(feature = "llvm-sys-110")]
+use llvm_sys_110 as llvm_sys;
+#[cfg(feature = "llvm-sys-120")]
+use llvm_sys_120 as llvm_sys;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "llvm-sys-110")] {
+        #[rustversion::since(1.52)]
+        compile_error!("Can not use LLVM11 with Rust >= 1.52");
+    }
+}
+
 use anyhow::{anyhow, Result};
 use llvm_sys::bit_writer::LLVMWriteBitcodeToFile;
 use llvm_sys::core::*;
@@ -139,9 +151,6 @@ pub unsafe fn process_ir(context: LLVMContextRef, module: LLVMModuleRef) -> Resu
         }
         func = LLVMGetNextFunction(func);
     }
-
-    // This removes .BTF sections. Do not call it.
-    // LLVMStripModuleDebugInfo(module);
 
     Ok(())
 }

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -291,6 +291,7 @@ pub struct PerCpuArray<'a, T: Clone> {
 
 // TODO Use PERF_MAX_STACK_DEPTH
 const BPF_MAX_STACK_DEPTH: usize = 127;
+const BPF_FS_MAGIC: i64 = 0xcafe4a11;
 
 #[repr(C)]
 pub struct BpfStackFrames {
@@ -498,7 +499,7 @@ fn pin_bpf_obj(fd: RawFd, file: impl AsRef<Path>) -> Result<()> {
             error!("error on statfs {:?}: {}", path, io::Error::last_os_error());
             return Err(Error::IO(io::Error::last_os_error()));
         }
-        if stat.f_type != libc::BPF_FS_MAGIC {
+        if stat.f_type as i64 != BPF_FS_MAGIC {
             error!("not BPF FS");
             return Err(Error::IO(io::Error::from(ErrorKind::PermissionDenied)));
         }


### PR DESCRIPTION
The latest Alpine Linux does not support LLVM 12 yet so use LLVM 11 if target env is `musl`

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>