### PR TITLE
Remove version fields from Cargo.toml that are not for `creates.io`

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["command-line"]
 clap = { version = "2.33", optional = true }
 bindgen = {version = "0.59.1", default-features = false, features = ["runtime"], optional = true}
 toml_edit = { version = "0.2", optional = true }
-bpf-sys = { version = "^2.0.0-rc1", path = "../bpf-sys", optional = true }
-redbpf = { version = "^2.0.0-rc1", path = "../redbpf", default-features = false, optional = true }
+bpf-sys = { version = "2.0.0-rc1", path = "../bpf-sys", optional = true }
+redbpf = { version = "2.0.0-rc1", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }

--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -9,15 +9,15 @@ license = "MIT OR Apache-2.0"
 keywords = ["bpf", "ebpf", "build", "bindgen", "redbpf"]
 
 [build-dependencies]
-cargo-bpf = { version = "*", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
-bpf-sys = { version = "*", path = "../../bpf-sys" }
+cargo-bpf = { path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
+bpf-sys = { path = "../../bpf-sys" }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = { version = "*", path = "../../redbpf-macros" }
-redbpf-probes = { version = "*", path = "../../redbpf-probes" }
+redbpf-macros = { path = "../../redbpf-macros" }
+redbpf-probes = { path = "../../redbpf-probes" }
 memoffset = "0.6.1"
 
 [features]

--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT OR Apache-2.0"
 keywords = ["bpf", "ebpf", "build", "bindgen", "redbpf"]
 
 [build-dependencies]
-cargo-bpf = { version = "*", path = "../../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { path = "../../cargo-bpf", default-features = false, features = ["build"] }
 
 [dependencies]
-probes = { version = "*", path = "../example-probes", package = "example-probes" }
+probes = { path = "../example-probes", package = "example-probes" }
 libc = "0.2"
 tokio = { version = "^1.0.1", features = ["rt", "signal", "time", "io-util", "net", "sync"] }
-redbpf = { version = "*", path = "../../redbpf", features = ["load"] }
+redbpf = { path = "../../redbpf", features = ["load"] }
 futures = "0.3"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"

--- a/redbpf-macros/Cargo.toml
+++ b/redbpf-macros/Cargo.toml
@@ -23,6 +23,6 @@ rustc_version = "0.3.0"
 
 [dev-dependencies]
 # redbpf-probes is needed by doctests
-redbpf-probes = { version = "^2.0.0-rc1", path = "../redbpf-probes" }
+redbpf-probes = { version = "2.0.0-rc1", path = "../redbpf-probes" }
 # memoffset is needed by doctests
 memoffset = "0.6"

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = { version = "^1.0.1", path = "../redbpf-macros" }
+redbpf-macros = { version = "2.0.0-rc1", path = "../redbpf-macros" }
 ufmt = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
-cargo-bpf = { version = "^2.0.0-rc1", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
-bpf-sys = { version = "^2.0.0-rc1", path = "../bpf-sys" }
+cargo-bpf = { version = "2.0.0-rc1", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
+bpf-sys = { version = "2.0.0-rc1", path = "../bpf-sys" }
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
 glob = "0.3.0"

--- a/redbpf-tools/Cargo.toml
+++ b/redbpf-tools/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 repository = "https://github.com/foniod/redbpf"
 
 [build-dependencies]
-cargo-bpf = { version = "^2.0.0-rc1", path = "../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { path = "../cargo-bpf", default-features = false, features = ["build"] }
 
 [dependencies]
 probes = { path = "./probes" }
-redbpf = {  version = "^2.0.0-rc1", path = "../redbpf", features = ["load"] }
+redbpf = { path = "../redbpf", features = ["load"] }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal", "time"] }
 futures = "0.3"
 getopts = "0.2"

--- a/redbpf-tools/probes/Cargo.toml
+++ b/redbpf-tools/probes/Cargo.toml
@@ -6,16 +6,16 @@ authors = ["Alessandro Decina <alessandro.d@gmail.com>", "Peter Parkanyi <p@symm
 repository = "https://github.com/foniod/redbpf"
 
 [build-dependencies]
-cargo-bpf = { version = "^2.0.0-rc1", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
+cargo-bpf = { path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
 glob = "0.3.0"
-bpf-sys = { version = "*", path = "../../bpf-sys" }
+bpf-sys = { path = "../../bpf-sys" }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = { version = "^2.0.0-rc1", path = "../../redbpf-macros" }
-redbpf-probes = { version = "^2.0.0-rc1", path = "../../redbpf-probes" }
+redbpf-macros = { path = "../../redbpf-macros" }
+redbpf-probes = { path = "../../redbpf-probes" }
 
 [features]
 default = []

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-bpf-sys = { path = "../bpf-sys", version = "^2.0.0-rc1" }
+bpf-sys = { path = "../bpf-sys", version = "2.0.0-rc1" }
 goblin = "0.4"
 zero = "0.1"
 libc = "0.2"


### PR DESCRIPTION
Version fields for redbpf packages are removed from `Cargo.toml`. But I only modified packages that are not uploaded to `creates.io`