### PR TITLE
Remove deprecated

### DIFF
--- a/examples/example-probes/src/mallocstacks/main.rs
+++ b/examples/example-probes/src/mallocstacks/main.rs
@@ -5,10 +5,10 @@ use redbpf_probes::uprobe::prelude::*;
 
 program!(0xFFFFFFFE, "GPL");
 
-#[map("stack_trace")]
+#[map]
 static mut stack_trace: StackTrace = StackTrace::with_max_entries(10240);
 
-#[map("malloc_event")]
+#[map]
 static mut malloc_event: PerfMap<MallocEvent> = PerfMap::with_max_entries(1024);
 
 #[uprobe]

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -165,9 +165,6 @@ pub fn impl_network_buffer_array(_: TokenStream) -> TokenStream {
 /// require strict naming conventions use `#[map(link_section = "foo")]`
 /// which place the map into a section called `foo`.
 ///
-/// **NOTE:** The `#[map("foo")` (which uses link section `maps/foo`) has
-/// been deprecated in favor of `#[map]` or `#[map(link_section = "maps/foo")]`
-///
 /// # Example
 ///
 /// ```no_run
@@ -212,15 +209,9 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
             NestedMeta::Lit(lit) => {
-                // Fallback to deprecated #[map("...")]
+                // panic if #[map("...")] is declared
                 if let Lit::Str(name) = lit {
-                    if link_section.is_some() {
-                        panic!("#[map(link_section = \"...\")] is specified multiple times");
-                    }
-                    #[cfg(RUSTC_IS_NIGHTLY)]
-                    Diagnostic::new(Level::Warning, "`#[map(\"..\")` has been deprecated in favor of `#[map]` or `#[map(link_section = \"..\")]`").emit();
-                    link_section = Some(format!("maps/{}", name.value()));
-                    allowed = true;
+                    panic!("expected #[map(link_section = \"maps/{}\")]", name.value());
                 }
             }
         }

--- a/redbpf-probes/src/tc/mod.rs
+++ b/redbpf-probes/src/tc/mod.rs
@@ -51,15 +51,8 @@ pub enum TcAction {
     /// Terminate the packet processing pipeline and allows the packet to
     /// proceed
     Ok = 0,
-    /// Terminate the packet processing pipeline and start classification from
-    /// the beginning
-    #[deprecated(note = "linux kernel commit `5cf8ca0e` (linux v4.3) removed this from cls_bpf")]
-    Reclassify,
     /// Terminate the packet processing pipeline and drops the packet
     Shot = 2,
-    /// Iterate to the next action, if available
-    #[deprecated(note = "linux kernel commit `5cf8ca0e` (linux v4.3) removed this from cls_bpf")]
-    Pipe,
     /// TC_ACT_SHOT will indicate to the kernel that the skb was released
     /// through kfree_skb() and return NET_XMIT_DROP to the callers for
     /// immediate feedback, whereas TC_ACT_STOLEN will release the skb through

--- a/redbpf-tools/probes/src/iotop/main.rs
+++ b/redbpf-tools/probes/src/iotop/main.rs
@@ -8,13 +8,13 @@ const REQ_OP_WRITE: u32 = 1;
 
 program!(0xFFFFFFFE, "GPL");
 
-#[map("start")]
+#[map]
 static mut start: HashMap<*const request, u64> = HashMap::with_max_entries(10240);
 
-#[map("processes")]
+#[map]
 static mut processes: HashMap<*const request, Process> = HashMap::with_max_entries(10240);
 
-#[map("counts")]
+#[map]
 static mut counts: HashMap<CounterKey, Counter> = HashMap::with_max_entries(10240);
 
 #[kprobe]

--- a/redbpf-tools/probes/src/knock/main.rs
+++ b/redbpf-tools/probes/src/knock/main.rs
@@ -13,16 +13,16 @@ program!(0xFFFFFFFE, "GPL");
 
 const TCP_FLAG_SYN: u16 = 0x0002u16.to_be();
 
-#[map("sequence")]
+#[map]
 static mut sequence: HashMap<u8, PortSequence> = HashMap::with_max_entries(1);
 
-#[map("knocks")]
+#[map]
 static mut knocks: HashMap<u32, Knock> = HashMap::with_max_entries(1024);
 
-#[map("knock_attempts")]
+#[map]
 static mut knock_attempts: PerfMap<KnockAttempt> = PerfMap::with_max_entries(1024);
 
-#[map("connections")]
+#[map]
 static mut connections: PerfMap<Connection> = PerfMap::with_max_entries(1024);
 
 #[xdp("knock")]

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -28,7 +28,6 @@ serde_json = { version = "^1.0", optional = true}
 ring = { version = "0.16", optional = true }
 
 futures = { version = "0.3", optional = true }
-mio = { version = "0.6", optional = true }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal", "net"], optional = true }
 tracing = "0.1.26"
 
@@ -36,4 +35,4 @@ tracing = "0.1.26"
 default = []
 build = []
 build_cache = ["serde_derive", "serde_json", "ring"]
-load = ["futures", "mio", "tokio"]
+load = ["futures", "tokio"]

--- a/redbpf/src/load/map_io.rs
+++ b/redbpf/src/load/map_io.rs
@@ -6,9 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use futures::prelude::*;
-use mio::unix::EventedFd;
-use mio::{Evented, PollOpt, Ready, Token};
-use std::io;
 use std::os::unix::io::RawFd;
 use std::pin::Pin;
 use std::slice;
@@ -18,39 +15,6 @@ use tokio::io::Interest;
 use tracing::error;
 
 use crate::{Event, PerfMap};
-
-// TODO Remove MapIo and upgrade mio.
-// It is pub-visibility so removing this is semver breaking change. Since mio
-// v0.7, `Evented` is not provided, new version of mio can not be used now.
-#[deprecated]
-pub struct MapIo(RawFd);
-
-#[allow(deprecated)]
-impl Evented for MapIo {
-    fn register(
-        &self,
-        poll: &mio::Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.0).register(poll, token, interest, opts)
-    }
-
-    fn reregister(
-        &self,
-        poll: &mio::Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.0).reregister(poll, token, interest, opts)
-    }
-
-    fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
-        EventedFd(&self.0).deregister(poll)
-    }
-}
 
 pub struct PerfMessageStream {
     poll: AsyncFd<RawFd>,


### PR DESCRIPTION
- remove `#[map("...")]`
- remove `MapIo`
- remove `TcAction::{Reclassify, Pipe}`