### PR TITLE
Change helper return values from i32 to i64

### DIFF
--- a/examples/example-probes/src/mallocstacks/main.rs
+++ b/examples/example-probes/src/mallocstacks/main.rs
@@ -15,7 +15,6 @@ static mut malloc_event: PerfMap<MallocEvent> = PerfMap::with_max_entries(1024);
 fn malloc(regs: Registers) {
     let mut mev = MallocEvent {
         stackid: 0,
-        _padding: 0,
         size: regs.parm1(),
     };
 

--- a/examples/example-probes/src/mallocstacks/mod.rs
+++ b/examples/example-probes/src/mallocstacks/mod.rs
@@ -1,7 +1,6 @@
 #[derive(Debug)]
 #[repr(C)]
 pub struct MallocEvent {
-    pub stackid: i32,
-    pub _padding: i32,
+    pub stackid: i64,
     pub size: u64,
 }

--- a/examples/example-userspace/examples/mallocstacks.rs
+++ b/examples/example-userspace/examples/mallocstacks.rs
@@ -23,7 +23,7 @@ struct AllocSize {
     frames: BpfStackFrames,
 }
 
-type Acc = Arc<Mutex<HashMap<i32, AllocSize>>>;
+type Acc = Arc<Mutex<HashMap<i64, AllocSize>>>;
 
 fn handle_malloc_event(acc: Acc, loaded: &Loaded, event: Box<[u8]>) {
     let mut acc = acc.lock().unwrap();

--- a/redbpf-probes/src/helpers.rs
+++ b/redbpf-probes/src/helpers.rs
@@ -96,7 +96,7 @@ pub fn bpf_ktime_get_ns() -> u64 {
 // For tracing programs, safely attempt to read `mem::size_of::<T>()` bytes from
 // address src.
 #[inline]
-pub unsafe fn bpf_probe_read<T>(src: *const T) -> Result<T, i32> {
+pub unsafe fn bpf_probe_read<T>(src: *const T) -> Result<T, i64> {
     let mut v: MaybeUninit<T> = MaybeUninit::uninit();
     let ret = gen::bpf_probe_read(
         v.as_mut_ptr() as *mut c_void,
@@ -104,8 +104,7 @@ pub unsafe fn bpf_probe_read<T>(src: *const T) -> Result<T, i32> {
         src as *const c_void,
     );
     if ret < 0 {
-        // TODO return i64
-        return Err(ret as i32);
+        return Err(ret);
     }
 
     Ok(v.assume_init())
@@ -130,7 +129,7 @@ pub fn bpf_perf_event_output(
     flags: u64,
     data: *const c_void,
     size: u64,
-) -> i32 {
+) -> i64 {
     unsafe {
         let f: unsafe extern "C" fn(
             ctx: *mut c_void,
@@ -138,7 +137,7 @@ pub fn bpf_perf_event_output(
             flags: u64,
             data: *const c_void,
             size: u64,
-        ) -> i32 = ::core::mem::transmute(25usize);
+        ) -> i64 = ::core::mem::transmute(25usize);
         f(ctx, map, flags, data, size)
     }
 }

--- a/redbpf-probes/src/maps.rs
+++ b/redbpf-probes/src/maps.rs
@@ -343,13 +343,12 @@ impl StackTrace {
         }
     }
 
-    pub unsafe fn stack_id(&mut self, ctx: *mut pt_regs, flag: u64) -> Result<c_int, c_int> {
+    pub unsafe fn stack_id(&mut self, ctx: *mut pt_regs, flag: u64) -> Result<i64, i64> {
         let ret = bpf_get_stackid(ctx as _, &mut self.def as *mut _ as _, flag);
-        // TODO return i64
         if ret >= 0 {
-            Ok(ret as i32)
+            Ok(ret)
         } else {
-            Err(ret as i32)
+            Err(ret)
         }
     }
 }
@@ -402,11 +401,10 @@ impl ProgramArray {
     /// (i.e. index is superior to the number of entries in the array), or
     /// if the maximum number of tail calls has been reached for this chain of
     /// programs.
-    pub unsafe fn tail_call<C>(&mut self, ctx: *mut C, index: u32) -> Result<(), i32> {
+    pub unsafe fn tail_call<C>(&mut self, ctx: *mut C, index: u32) -> Result<(), i64> {
         let ret = bpf_tail_call(ctx as *mut _, &mut self.def as *mut _ as *mut c_void, index);
         if ret < 0 {
-            // TODO return i64
-            return Err(ret as i32);
+            return Err(ret);
         }
 
         Ok(())

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -2015,13 +2015,13 @@ impl StackTrace<'_> {
         StackTrace { base: map }
     }
 
-    pub fn get(&mut self, mut id: libc::c_int) -> Option<BpfStackFrames> {
+    pub fn get(&mut self, mut id: i64) -> Option<BpfStackFrames> {
         unsafe {
             let mut value = MaybeUninit::uninit();
 
             let ret = bpf_sys::bpf_map_lookup_elem(
                 self.base.fd,
-                &mut id as *mut libc::c_int as _,
+                &mut id as *const _ as *mut _,
                 value.as_mut_ptr() as *mut _,
             );
 
@@ -2033,12 +2033,9 @@ impl StackTrace<'_> {
         }
     }
 
-    pub fn delete(&mut self, id: libc::c_int) -> Result<()> {
+    pub fn delete(&mut self, id: i64) -> Result<()> {
         unsafe {
-            let ret = bpf_sys::bpf_map_delete_elem(
-                self.base.fd,
-                &id as *const libc::c_int as *mut libc::c_int as _,
-            );
+            let ret = bpf_sys::bpf_map_delete_elem(self.base.fd, &id as *const _ as *mut _);
 
             if ret == 0 {
                 Ok(())


### PR DESCRIPTION
Follow up libbpf's 6f8e021c commit

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>

This resolves #145 

- redbpf_probes::helpers::bpf_probe_read
- redbpf_probes::helpers::bpf_perf_event_output
- redbpf_probes::maps::StackTrace::stack_id
- redbpf_probes::maps::ProgramArray::tail_call

and 
- redbpf::StackTrace::get, delete