### PR TITLE
Check the exit code of `make` executed to build redbpf static library

### DIFF
--- a/bpf-sys/build.rs
+++ b/bpf-sys/build.rs
@@ -45,8 +45,16 @@ fn main() {
     let out_path = PathBuf::from(out_dir);
 
     // -fPIE is passed because Fedora 35 requires it. Other distros like Ubuntu
-    // 21.04, Alpine 3.14 also works find with it
-    Command::new("make").args(format!("-C libbpf/src BUILD_STATIC_ONLY=1 OBJDIR={}/libbpf DESTDIR={out_dir} INCLUDEDIR= LIBDIR= UAPIDIR=", out_dir=env::var("OUT_DIR").unwrap()).split(" ")).arg("CFLAGS=-g -O2 -Werror -Wall -fPIE").arg("install").status().unwrap();
+    // 21.04, Alpine 3.14 also works fine with it
+    if !Command::new("make")
+        .args(format!("-C libbpf/src BUILD_STATIC_ONLY=1 OBJDIR={out_dir}/libbpf DESTDIR={out_dir} INCLUDEDIR= LIBDIR= UAPIDIR=", out_dir=env::var("OUT_DIR").unwrap()).split(" "))
+        .arg("CFLAGS=-g -O2 -Werror -Wall -fPIE")
+        .arg("install")
+        .status()
+        .expect("error on executing `make` command for building `libbpf` static library")
+        .success() {
+        panic!("failed to build `libbpf` static library");
+    }
     let bindings = bindgen::Builder::default()
         .header("libbpf_xdp.h")
         .header("libbpf/src/bpf.h")


### PR DESCRIPTION
`bpf-sys` does not check the exit code of `make` command so that an
worse error occurs and users get in trouble to figure out a root cause.

`make` fails if `libelf` header files (libelf-dev or
elfutils-libelf-devel package) do not exist. However without the
checking of exit code, the build script of `bpf-sys` succeeds and
another error occurs while compiling bpf-sys:

> error: could not find native static library `bpf`, perhaps an -L flag is missing?
> error: could not compile `bpf-sys` due to previous error

With this error message, it is not easy to understand the root cause and
users can not come up with what they should do next.

So it is better to check the exit code of `make` and panic unless it
succeeds. This behavior produces more comprehensive error messages:

>   make: Entering directory '/home/esrse/opensource/redbpf/bpf-sys/libbpf/src'
>     MKDIR    staticobjs
>     CC       bpf.o
>     CC       btf.o
>   make: Leaving directory '/home/esrse/opensource/redbpf/bpf-sys/libbpf/src'

>   --- stderr
>   btf.c:18:10: fatal error: gelf.h: No such file or directory
>      18 | #include <gelf.h>
>         |          ^~~~~~~~
>   compilation terminated.
>   make: *** [Makefile:113: /home/esrse/opensource/redbpf/target/debug/build/bpf-sys-adb9a2ddcc715ce3/out/libbpf/staticobjs/btf.o] Error 1
>   thread 'main' panicked at 'failed to build `libbpf` static library', bpf-sys/build.rs:56:9

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>


----

This PR alleviates #177 problem case.