### PR TITLE
Fix standalone crate build for tools + examples

### DIFF
--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bpf", "ebpf", "build", "bindgen", "redbpf"]
 
 [build-dependencies]
-cargo-bpf = { path = "../../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { path = "../../cargo-bpf", default-features = false, features = ["build", "llvm12"] }
 
 [dependencies]
 probes = { path = "../example-probes", package = "example-probes" }

--- a/redbpf-tools/Cargo.toml
+++ b/redbpf-tools/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 repository = "https://github.com/foniod/redbpf"
 
 [build-dependencies]
-cargo-bpf = { path = "../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { path = "../cargo-bpf", default-features = false, features = ["build", "llvm12"] }
 
 [dependencies]
 probes = { path = "./probes" }


### PR DESCRIPTION
Building the `redbpf-tools` crate by itself currently fails, which can easily be verified with `cd redbpf-tools && cargo build`. The problem is that the `llvm-sys` dependency is now optional in `cargo-bpf`, and since the default features are disabled there is no `llvm-sys` version available unless one is explicitly specified through a feature.

So, why wasn't this noticed by CI already?

Because the build actually works when building the entire workspace instead of just the tools crate. Since `cargo-bpf` is declared as a subcrate, it is built with the default features, which include `llvm12`. Apparently, Cargo "transfers" the dependencies pulled in through that build to `redbpf-tools`, *even though `redbpf-tools` requested non-default crate features from `cargo-bpf`.* I find this behavior from Cargo strange to say the least, but perhaps there is a good reason to do this that I just don't understand. Anyway, it should be possible to build subcrates in isolation, and this PR achieves that.
