### PR TITLE
Disable Alpine until they have LLVM12

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,7 +109,9 @@ jobs:
         /bin/bash -c 'cargo clean && /lib/modules/*/build/scripts/extract-vmlinux /lib/modules/*/vmlinuz > /boot/vmlinux && export REDBPF_VMLINUX=/boot/vmlinux && cargo build && cargo build --examples'
 
   alpine-314-build-test:
+    name: Alpine 3.14 (Disabled until LLVM12 support)
     runs-on: ubuntu-latest
+    if: false
     steps:
     - uses: actions/checkout@v2
     - name: Build host info
@@ -135,7 +137,7 @@ jobs:
     - ubuntu-2104-build-test
     - ubuntu-2004-build-test
     - ubuntu-1804-build-test
-    - alpine-314-build-test
+    # - alpine-314-build-test
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Disable Alpine builds on CI until they ship with LLVM12. I don't see how we could simultaneously fix the issue described in #187 and maintain Alpine support, as they still ship with LLVM11 _and_ the newest Rust compiler.

@p-e-w @rhdxmr Please do let me know if you know of a cleaner solution for this.