### PR TITLE
Fix docsrs

### DIFF
--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["bpf", "ebpf", "ffi"]
 zero = "0.1"
 libc = "0.2"
 regex = { version = "1.5" }
+glob = "0.3.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = { version = "3.1", optional = true}
 lazy_static = "1.0"
 glob = "0.3"
 anyhow = "1.0"
+llvm-sys-100 = { version = "100", optional = true, package = "llvm-sys" }
 llvm-sys-110 = { version = "110", optional = true, package = "llvm-sys" }
 llvm-sys-120 = { version = "120", optional = true, package = "llvm-sys" }
 cfg-if = "1.0"
@@ -43,10 +44,14 @@ rustversion = "1.0"
 default = ["command-line", "llvm12"]
 bindings = ["bpf-sys", "bindgen", "syn", "quote", "proc-macro2", "tempfile"]
 build = ["bindings", "libc", "toml_edit"]
+llvm10 = ["llvm-sys-100"]
 llvm11 = ["llvm-sys-110"]
 llvm12 = ["llvm-sys-120"]
 build-c = []
 command-line = ["build", "clap", "redbpf/load", "futures", "tokio", "hexdump"]
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = false
+no-default-features = true
+features = ["command-line", "llvm10"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cargo-bpf/src/build_constants.rs
+++ b/cargo-bpf/src/build_constants.rs
@@ -32,6 +32,7 @@ lazy_static! {
             "-Wall",
             "-Werror",
             "-Wunused",
+            "-Wno-unknown-warning-option",
             "-Wno-frame-address",
             "-Wno-unused-value",
             "-Wno-pointer-sign",

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -1,12 +1,18 @@
-#[cfg(feature = "llvm-sys-110")]
-use llvm_sys_110 as llvm_sys;
-#[cfg(feature = "llvm-sys-120")]
-use llvm_sys_120 as llvm_sys;
-
 cfg_if::cfg_if! {
-    if #[cfg(feature = "llvm-sys-110")] {
+    if #[cfg(feature = "llvm-sys-120")] {
+        use llvm_sys_120 as llvm_sys;
+    } else if #[cfg(feature = "llvm-sys-110")] {
+        use llvm_sys_110 as llvm_sys;
+        #[cfg(not(docsrs))]
         #[rustversion::since(1.52)]
         compile_error!("Can not use LLVM11 with Rust >= 1.52");
+    } else if #[cfg(feature = "llvm-sys-100")] {
+        use llvm_sys_100 as llvm_sys;
+        #[cfg(not(docsrs))]
+        #[rustversion::since(1.47)]
+        compile_error!("Can not use LLVM10 with Rust >= 1.47");
+    } else {
+        compile_error!("At least one of `llvm12`, `llvm11` and `llvm10` features should be specified");
     }
 }
 

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -18,7 +18,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use syn::visit::Visit;
 
-use bpf_sys::headers::{get_custom_header_path, get_custom_header_version};
+use bpf_sys::headers::{
+    available_kernel_header_paths, get_custom_header_path, get_custom_header_version,
+    set_custom_header_path,
+};
 use bpf_sys::type_gen::get_custom_vmlinux_path;
 use cargo_bpf_lib::bindgen as bpf_bindgen;
 use syn::{
@@ -270,6 +273,13 @@ fn main() {
         .finish();
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
+    if let Ok(_) = env::var("DOCS_RS") {
+        let mut paths = available_kernel_header_paths();
+        paths.sort();
+        if let Some(path) = paths.pop() {
+            set_custom_header_path(path);
+        }
+    }
     rerun_if_changed_dir("include");
 
     if get_custom_vmlinux_path().is_some() {


### PR DESCRIPTION
Currently it is failed to build documentation of cargo-bpf and redbpf-probes in
docs.rs. redbpf-probes has never succeeded in building documentation in docs.rs
and cargo-bpf has failed since Sep 16, 2020.

This PR resolves the problem by changing below:
* To build doc of cargo-bpf in docs.rs, use `llvm-sys-100`
* To build doc of redbpf-probes in docs.rs, add `-Wno-unknown-warning-option` and set the `KERNEL_SOURCE` environment variable.