### PR TITLE
sk_lookup loading support

### DIFF
--- a/redbpf/src/error.rs
+++ b/redbpf/src/error.rs
@@ -20,6 +20,7 @@ pub enum Error {
     SymbolNotFound(String),
     ProgramAlreadyLoaded,
     ProgramNotLoaded,
+    ProgramAlreadyLinked,
     ElfError,
     BTF(String),
 }

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -2615,8 +2615,7 @@ impl<'a> SockMap<'a> {
         Ok(SockMap { base: map })
     }
 
-    pub fn set(&mut self, mut idx: u32, fd: RawFd) -> Result<()> {
-        let mut fd = fd as u64;
+    pub fn set(&mut self, mut idx: u32, mut fd: RawFd) -> Result<()> {
         let ret = unsafe {
             bpf_sys::bpf_map_update_elem(
                 self.base.fd,

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use crate::load::map_io::PerfMessageStream;
 use crate::{cpus, Program};
 use crate::{
-    Error, KProbe, Map, Module, PerfMap, SocketFilter, StreamParser, StreamVerdict, TaskIter,
-    UProbe, XDP,
+    Error, KProbe, Map, Module, PerfMap, SkLookup, SocketFilter, StreamParser, StreamVerdict,
+    TaskIter, UProbe, XDP,
 };
 
 #[derive(Debug)]
@@ -167,6 +167,14 @@ impl Loaded {
 
     pub fn stream_verdict_mut(&mut self, name: &str) -> Option<&mut StreamVerdict> {
         self.module.stream_verdict_mut(name)
+    }
+
+    pub fn sk_lookups_mut(&mut self) -> impl Iterator<Item = &mut SkLookup> {
+        self.module.sk_lookups_mut()
+    }
+
+    pub fn sk_lookup_mut(&mut self, name: &str) -> Option<&mut SkLookup> {
+        self.module.sk_lookup_mut(name)
     }
 
     pub fn task_iters(&self) -> impl Iterator<Item = &TaskIter> {


### PR DESCRIPTION
This pull request is pretty simple and just adds support for loading `sk_lookup` programs to the `redbpf` crate. I'm opening it as a draft as

1. Support hasn't been added to the rest of the crates
~~2. `sk_lookup` requires a relatively recent kernel version (5.9) and merging this would probably break things for many people~~

Point 1 could be addressed by simply building upon this to add support everywhere else (I'll probably do it at some point but I don't personally need it at the moment), ~~while for point 2 it might be interesting to consider feature-gating different program types.~~