### PR TITLE
Add support for sk_lookup BPF programs

### DIFF
--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -109,6 +109,7 @@ pub mod kprobe;
 pub mod maps;
 pub mod net;
 pub mod registers;
+pub mod sk_lookup;
 pub mod socket;
 pub mod socket_filter;
 pub mod sockmap;

--- a/redbpf-probes/src/maps.rs
+++ b/redbpf-probes/src/maps.rs
@@ -545,4 +545,21 @@ impl SockMap {
             _ => panic!("invalid return value of bpf_sk_redirect_map"),
         }
     }
+
+    /// Get the socket referenced by this sockmap at index `key`.
+    pub fn get_mut(&mut self, key: &u32) -> Option<crate::socket::Socket> {
+        unsafe {
+            let value = bpf_map_lookup_elem(
+                &mut self.def as *mut _ as *mut c_void,
+                key as *const _ as *const c_void,
+            );
+            if value.is_null() {
+                None
+            } else {
+                Some(crate::socket::Socket {
+                    inner: &mut *(value as *mut c_void),
+                })
+            }
+        }
+    }
 }

--- a/redbpf-probes/src/sk_lookup/mod.rs
+++ b/redbpf-probes/src/sk_lookup/mod.rs
@@ -1,0 +1,87 @@
+// Copyright 2020 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Utilities to work with sk_lookup programs.
+
+pub mod prelude;
+
+use crate::bindings::*;
+use cty::*;
+
+/// Context object provided to sk_lookup programs.
+#[derive(Copy, Clone)]
+pub struct SkLookupCtx {
+    /// The low level bpf_sk_lookup instance.
+    pub ctx: *mut bpf_sk_lookup,
+}
+
+/// An IP address, either IPv4 or IPv6.
+#[derive(Copy, Clone)]
+pub enum IpAddr {
+    V4(Ipv4Addr),
+    V6(Ipv6Addr),
+}
+
+/// IP protocol, either TCP or UDP.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum IpProtocol {
+    TCP,
+    UDP,
+}
+
+/// An IPv4 address.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Ipv4Addr(pub u32);
+
+/// An IPv6 address.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Ipv6Addr(pub [u32; 4]);
+
+/// Convenience functions wrapping the raw `struct bpf_sk_lookup`
+impl SkLookupCtx {
+    /// Get the protocol of the incoming connection.
+    #[inline]
+    pub fn protocol(&self) -> IpProtocol {
+        match unsafe { (*self.ctx).protocol } {
+            IPPROTO_TCP => IpProtocol::TCP,
+            IPPROTO_UDP => IpProtocol::UDP,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Get the local address of the incoming connection.
+    #[inline]
+    pub fn local_addr(&self) -> IpAddr {
+        match unsafe { (*self.ctx).family } {
+            AF_INET => IpAddr::V4(Ipv4Addr(unsafe { (*self.ctx).local_ip4 })),
+            AF_INET6 => IpAddr::V6(Ipv6Addr(unsafe { (*self.ctx).local_ip6 })),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Get the local port of the incoming connection.
+    #[inline]
+    pub fn local_port(&self) -> u32 {
+        unsafe { (*self.ctx).local_port }
+    }
+
+    /// Get the remote address of the incoming connection.
+    #[inline]
+    pub fn remote_addr(&self) -> IpAddr {
+        match unsafe { (*self.ctx).family } {
+            AF_INET => IpAddr::V4(Ipv4Addr(unsafe { (*self.ctx).remote_ip4 })),
+            AF_INET6 => IpAddr::V6(Ipv6Addr(unsafe { (*self.ctx).remote_ip6 })),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Get the remote port of the incoming connection.
+    #[inline]
+    pub fn remote_port(&self) -> u32 {
+        unsafe { (*self.ctx).remote_port }
+    }
+}

--- a/redbpf-probes/src/sk_lookup/mod.rs
+++ b/redbpf-probes/src/sk_lookup/mod.rs
@@ -9,8 +9,8 @@
 
 pub mod prelude;
 
-use crate::{bindings::*, socket::Socket};
 use crate::xdp::prelude::bpf_sk_assign;
+use crate::{bindings::*, socket::Socket};
 use cty::*;
 
 /// Context object provided to sk_lookup programs.
@@ -49,8 +49,7 @@ impl SkLookupCtx {
     pub fn protocol(&self) -> IpProtocol {
         match unsafe { (*self.ctx).protocol } {
             IPPROTO_TCP => IpProtocol::TCP,
-            IPPROTO_UDP => IpProtocol::UDP,
-            _ => unreachable!(),
+            _ => IpProtocol::UDP,
         }
     }
 
@@ -59,8 +58,7 @@ impl SkLookupCtx {
     pub fn local_addr(&self) -> IpAddr {
         match unsafe { (*self.ctx).family } {
             AF_INET => IpAddr::V4(Ipv4Addr(unsafe { (*self.ctx).local_ip4 })),
-            AF_INET6 => IpAddr::V6(Ipv6Addr(unsafe { (*self.ctx).local_ip6 })),
-            _ => unreachable!(),
+            _ => IpAddr::V6(Ipv6Addr(unsafe { (*self.ctx).local_ip6 })),
         }
     }
 

--- a/redbpf-probes/src/sk_lookup/mod.rs
+++ b/redbpf-probes/src/sk_lookup/mod.rs
@@ -9,7 +9,8 @@
 
 pub mod prelude;
 
-use crate::bindings::*;
+use crate::{bindings::*, socket::Socket};
+use crate::xdp::prelude::bpf_sk_assign;
 use cty::*;
 
 /// Context object provided to sk_lookup programs.
@@ -83,5 +84,16 @@ impl SkLookupCtx {
     #[inline]
     pub fn remote_port(&self) -> u32 {
         unsafe { (*self.ctx).remote_port }
+    }
+
+    /// Assigns this connection to the specified socket.
+    #[inline]
+    pub fn assign(&self, socket: &mut Socket) -> Result<(), i64> {
+        let ret = unsafe { bpf_sk_assign(self.ctx as *mut c_void, socket.inner, 0) };
+        if ret >= 0 {
+            Ok(())
+        } else {
+            Err(ret)
+        }
     }
 }

--- a/redbpf-probes/src/sk_lookup/prelude.rs
+++ b/redbpf-probes/src/sk_lookup/prelude.rs
@@ -18,6 +18,6 @@ pub use crate::helpers::*;
 pub use crate::maps::*;
 pub use crate::registers::*;
 pub use crate::sk_lookup::*;
-pub use crate::socket::{SkAction, SkBuff};
+pub use crate::socket::{SkAction, SkBuff, Socket};
 pub use cty::*;
-pub use redbpf_macros::{sk_lookup, map, program};
+pub use redbpf_macros::{map, program, sk_lookup};

--- a/redbpf-probes/src/sk_lookup/prelude.rs
+++ b/redbpf-probes/src/sk_lookup/prelude.rs
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The sk_lookup Prelude
+//!
+//! The purpose of this module is to alleviate imports of the sk_lookup programs
+//! by adding a glob import to the top of sk_lookup programs:
+//!
+//! ```
+//! use redbpf_probes::sk_lookup::prelude::*;
+//! ```
+pub use crate::bindings::*;
+pub use crate::helpers::*;
+pub use crate::maps::*;
+pub use crate::registers::*;
+pub use crate::sk_lookup::*;
+pub use crate::socket::{SkAction, SkBuff};
+pub use cty::*;
+pub use redbpf_macros::{sk_lookup, map, program};

--- a/redbpf-probes/src/socket.rs
+++ b/redbpf-probes/src/socket.rs
@@ -2,6 +2,7 @@
 
 use crate::bindings::*;
 use crate::helpers::bpf_skb_load_bytes;
+use crate::xdp::prelude::bpf_sk_release;
 use core::mem::{size_of, MaybeUninit};
 
 pub trait FromBe {
@@ -81,5 +82,16 @@ impl SkBuff {
 
             Ok(data.assume_init().from_be())
         }
+    }
+}
+
+/// A wrapper around a low-level socket.
+pub struct Socket {
+    pub inner: *mut cty::c_void,
+}
+
+impl Drop for Socket {
+    fn drop(&mut self) {
+        unsafe { bpf_sk_release(self.inner) };
     }
 }


### PR DESCRIPTION
This follows up on https://github.com/foniod/redbpf/pull/216 on the BPF side of things.

Currently this is a work in progress, but should expose what is needed to write some `sk_lookup` programs.