### PR TITLE
Raise compile error when the alignment of value > 8 bytes

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -258,13 +258,21 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
         let mod_ident = syn::Ident::new(&mod_name, static_item.ident.span());
         let ktype = key_type.unwrap();
         let vtype = value_type.unwrap();
+        // CAUTION: When you change the names (MAP_BTF_XXXX and
+        // MAP_VALUE_ALIGN_XXXX) you should consider changing corresponding
+        // parts that use them.
         let map_btf_name = format!("MAP_BTF_{}", static_item.ident.to_string());
         let map_btf_ident = syn::Ident::new(&map_btf_name, static_item.ident.span());
+        let value_align_name = format!("MAP_VALUE_ALIGN_{}", static_item.ident.to_string());
+        let value_align_ident = syn::Ident::new(&value_align_name, static_item.ident.span());
         tokens.extend(quote! {
             mod #mod_ident {
                 #[allow(unused_imports)]
                 use super::*;
-                use core::mem;
+                use core::mem::{self, MaybeUninit};
+
+                #[no_mangle]
+                static #value_align_ident: MaybeUninit<#vtype> = MaybeUninit::uninit();
 
                 #[repr(C)]
                 struct MapBtf {


### PR DESCRIPTION
Raise compile error when the alignment of value of BPF map is greater than 8
bytes.

`cargo-bpf::llvm` is modified to implement this feature. This decision incurs
tightening coupling between `cargo-bpf` and `redbpf-macros`. I also considered
raising runtime error when loading maps in `redbpf` but I thought the compile
error is more helpful to users than runtime errors.


Modifying `cargo-bpf::llvm` was the last resort. Before trying modifying it, I
had tried 2 other methods.

1. use `compile_error!` macro.

I wanted to use it because it is very intuitive and understandable error
message can be provided to users. But I couldn't figure out including
`compile_error!` conditionally by comparing the alignment... I found that
including `compile_error!` conditionally can only be achieved by `macro_rules!`
or `#[cfg(...)]`. However I don't know how to make use of them to include
`compile_error!` by comparing the alignment.


2. use const assert technique

I tried the code below
 
```diff
modified   redbpf-macros/src/lib.rs
@@ -266,6 +266,19 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
                 use super::*;
                 use core::mem;
 
+                macro_rules! check_value_align_le_8_bytes {
+                    ($x:expr $(,)?) => {
+                        const ASSERT: bool = $x;
+                        const LEN: usize = if ASSERT {
+                            0
+                        } else {
+                            1
+                        };
+                        const _: [(); 0] = [(); LEN];
+                    };
+                }
+                check_value_align_le_8_bytes!(mem::align_of::<#vtype>() <= 8);
+
                 #[repr(C)]
                 struct MapBtf {
                     key_type: #ktype,
```


It worked. It raised compile error as expected but the error message is
diffcult to understand.. The only hint users can understand is the macro
name... but I think it is insufficient.

```
error[E0308]: mismatched types
  --> src/devqueue/main.rs:12:1
   |
12 | #[map]
   | ^^^^^^ expected an array with a fixed size of 0 elements, found one with 1 element
   |
   = note: this error originates in the macro `check_value_align_le_8_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
```



----

This is the basis why the item whose alignment exceeds 8 bytes are
banned.

1. In official Rust documents, it is stated that misaligned pointers or
   references lead to undefined behavior.
2. In BPF programs, the pointer returned by bpf_map_lookup_elem is
   misaligned because the value the pointer points to is merely 8 bytes
   aligned data.
3. Hence, creating reference of the value, or dereferencing the pointer
   incurs undefined behavior.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>
