### PR TITLE
Find if get or get_mut method of RedBPF maps are called

### DIFF
--- a/examples/example-userspace/build.rs
+++ b/examples/example-userspace/build.rs
@@ -19,14 +19,16 @@ fn main() {
     if env::var("CARGO_FEATURE_KERNEL5_8").is_ok() {
         features.push(String::from("kernel5_8"));
     }
-    cargo_bpf::build_with_features(
+    if let Err(e) = cargo_bpf::build_with_features(
         &cargo,
         &probes,
         &target.join("target"),
         &mut Vec::new(),
         &features,
-    )
-    .expect("couldn't compile probes");
+    ) {
+        eprintln!("{}", e);
+        panic!("probes build failed");
+    }
 
     cargo_bpf::probe_files(&probes)
         .expect("couldn't list probe files")


### PR DESCRIPTION
Previously cargo-bpf raises an error if the alignment of value is
greater than 8 bytes. But this is inappropriate to some BPF program that
never calls get/get_mut. Since calling these methods creates references
of possibly misaligned data, it is okay to permit values that have
alignment greater than 8 bytes if get/get_mut is not called anywhere in
BPF programs.

Find if get/get_mut method is called by inspecting LLVM bitcode and
raise an error.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>