### PR TITLE
add p0f as example

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -78,3 +78,8 @@ required-features = ["probes", "kernel5_8"]
 name = "hashmaps"
 path = "src/hashmaps/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "p0f"
+path = "src/p0f/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/lib.rs
+++ b/examples/example-probes/src/lib.rs
@@ -17,3 +17,4 @@ pub mod mallocstacks;
 pub mod tasks;
 pub mod tcp_lifetime;
 pub mod vfsreadlat;
+pub mod p0f;

--- a/examples/example-probes/src/p0f/main.rs
+++ b/examples/example-probes/src/p0f/main.rs
@@ -1,0 +1,312 @@
+#![no_std]
+#![no_main]
+
+use redbpf_probes::{bindings::iphdr, bindings::tcphdr, net::Transport, xdp::prelude::*};
+
+use example_probes::p0f::{
+    self, Quirks, TcpOptionMss, TcpOptionSackok, TcpOptionU32, TcpOptionWscale, TcpSignature,
+};
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map(link_section = "maps/log_events")]
+static mut log_events: PerfMap<usize> = PerfMap::with_max_entries(512);
+
+#[map(link_section = "maps/tcp_signatures")]
+static mut tcp_signatures: PerfMap<TcpSignature> = PerfMap::with_max_entries(512);
+
+// #[inline(always)]
+#[inline(never)]
+fn parse_tcp_signature(ctx: &XdpContext, tcp_header: &tcphdr, tcp_sig: &mut TcpSignature) -> bool {
+    tcp_sig.set_quirk(Quirks::ZERO_SEQ, tcp_header.seq == 0);
+
+    if tcp_header.ack() != 0 {
+        tcp_sig.set_quirk(Quirks::ZERO_ACK, tcp_header.ack_seq == 0);
+    } else {
+        tcp_sig.set_quirk(Quirks::NZ_ACK, tcp_header.ack_seq != 0);
+    }
+
+    if tcp_header.urg() != 0 {
+        tcp_sig.set_quirk_true(Quirks::URG);
+    } else {
+        tcp_sig.set_quirk(Quirks::NZ_URG, tcp_header.urg_ptr != 0);
+    }
+
+    tcp_sig.set_quirk(Quirks::PUSH, tcp_header.psh() != 0);
+    tcp_sig.win = tcp_header.window;
+
+    // let's do tcp options
+    let mut tcp_option_pos = match unsafe { ctx.ptr_after(tcp_header as *const tcphdr) } {
+        Ok(pos) => pos as *const u8 as usize,
+        Err(_) => return false,
+    };
+
+    let tcp_option_end = tcp_header as *const tcphdr as usize + (tcp_header.doff() * 4) as usize;
+    if tcp_option_end > ctx.data_end() {
+        return false;
+    }
+
+    tcp_sig.pay_class = (ctx.data_end() != tcp_option_end) as i8;
+
+    // unsafe {
+    //     log_events.insert(&ctx, &MapData::new(tcp_option_pos as usize));
+    // }
+
+    for _ in 0..p0f::MAX_TCP_OPT - 6 {
+        if tcp_option_pos >= tcp_option_end {
+            return true;
+        }
+
+        // return true means finished
+        if parse_tcp_option(ctx, &mut tcp_option_pos, tcp_option_end, tcp_sig) {
+            break;
+        }
+    }
+
+    if tcp_option_pos != tcp_option_end {
+        tcp_sig.set_quirk(Quirks::OPT_BAD, true);
+    }
+
+    true
+}
+
+#[inline(never)]
+// #[inline(always)]
+fn parse_tcp_option(
+    ctx: &XdpContext,
+    tcp_option_pos: &mut usize,
+    tcp_option_end: usize,
+    tcp_sig: &mut TcpSignature,
+) -> bool {
+    let data_end = ctx.data_end();
+
+    let tcp_opt = unsafe { *(*tcp_option_pos as *const u8) };
+    tcp_sig.add_opt(tcp_opt);
+
+    // skip the opt kind byte
+    if *tcp_option_pos + 2 > data_end {
+        return true;
+    }
+    *tcp_option_pos += 1;
+
+    match tcp_opt {
+        //  EOL is a single-byte option that aborts further option parsing.
+        p0f::TCPOPT_EOL => unsafe {
+            // EOL is a single-byte option that aborts further option parsing.
+            // Take note of how many bytes of option data are left, and if any of them are non-zero
+            if *tcp_option_pos < tcp_option_end {
+                tcp_sig.opt_eol_pad = (tcp_option_end - *tcp_option_pos) as u8;
+
+                // the padding is used to make sure tcp header is 32bit aligned, so it should be 4 bytes at most
+                for _ in 0..4 {
+                    if *(*tcp_option_pos as *const u8) != 0 as u8 {
+                        tcp_sig.set_quirk_true(Quirks::OPT_EOL_NZ);
+                        return true;
+                    }
+
+                    if *tcp_option_pos + 2 > data_end || *tcp_option_pos + 2 > tcp_option_end {
+                        return true;
+                    }
+                    *tcp_option_pos += 1;
+                }
+            }
+            return true;
+        },
+
+        // MSS is a four-byte option with specified size: type, len, mss (u16)
+        p0f::TCPOPT_MSS => unsafe {
+            if *tcp_option_pos + core::mem::size_of::<TcpOptionMss>() > data_end {
+                return true;
+            }
+            let tcp_opt_mss: *const TcpOptionMss = *tcp_option_pos as *const TcpOptionMss;
+
+            if (*tcp_opt_mss).len != 4 as u8 {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+            }
+            tcp_sig.mss = i16::from_be((*tcp_opt_mss).mss) as i32;
+
+            if *tcp_option_pos + 4 > data_end {
+                return true;
+            }
+            *tcp_option_pos += 3;
+        },
+
+        //  WS is a three-byte option with specified size: type, len, shift
+        p0f::TCPOPT_WSCALE => unsafe {
+            if *tcp_option_pos + core::mem::size_of::<TcpOptionWscale>() > data_end {
+                return true;
+            }
+            let tcp_opt_wscale: *const TcpOptionWscale = *tcp_option_pos as *const TcpOptionWscale;
+
+            if (*tcp_opt_wscale).len != 3 as u8 {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+            }
+
+            tcp_sig.wscale = (*tcp_opt_wscale).wscale as i16;
+            if tcp_sig.wscale > 14 {
+                tcp_sig.set_quirk_true(Quirks::OPT_EXWS);
+            }
+
+            if *tcp_option_pos + 3 > data_end {
+                return true;
+            }
+            *tcp_option_pos += 2;
+        },
+
+        //  SACKOK is a two-byte option with specified size
+        p0f::TCPOPT_SACKOK => unsafe {
+            if *tcp_option_pos + core::mem::size_of::<TcpOptionSackok>() > data_end {
+                return true;
+            }
+            let tcp_opt_sackok: *const TcpOptionSackok = *tcp_option_pos as *const TcpOptionSackok;
+
+            if (*tcp_opt_sackok).len != 2 as u8 {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+            }
+
+            if *tcp_option_pos + 2 > data_end {
+                return true;
+            }
+            *tcp_option_pos += 1;
+        },
+
+        // SACK is a variable-length option of 10 to 34 bytes
+        p0f::TCPOPT_SACK => unsafe {
+            if *tcp_option_pos + core::mem::size_of::<TcpOptionU32>() > data_end {
+                return true;
+            }
+            let tcp_opt_sack: *const TcpOptionU32 = *tcp_option_pos as *const TcpOptionU32;
+
+            let len = (*tcp_opt_sack).len;
+            if len < 10 as u8 || len > 34 as u8 {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+                return true;
+            }
+
+            if len == 10 {
+                if *tcp_option_pos + 10 > data_end {
+                    return true;
+                }
+                *tcp_option_pos += 9;
+            } else if len == 18 {
+                if *tcp_option_pos + 18 > data_end {
+                    return true;
+                }
+                *tcp_option_pos += 17;
+            } else if len == 26 {
+                if *tcp_option_pos + 26 > data_end {
+                    return true;
+                }
+                *tcp_option_pos += 25;
+            } else if len == 34 {
+                if *tcp_option_pos + 34 > data_end {
+                    return true;
+                }
+                *tcp_option_pos += 33;
+            } else {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+                return true;
+            };
+        },
+
+        // Timestamp is a ten-byte option with specified size
+        p0f::TCPOPT_TSTAMP => unsafe {
+            if *tcp_option_pos + core::mem::size_of::<TcpOptionU32>() > data_end {
+                return true;
+            }
+            let tcp_opt_tstamp: *const TcpOptionU32 = *tcp_option_pos as *const TcpOptionU32;
+
+            if (*tcp_opt_tstamp).len != 10 as u8 {
+                tcp_sig.set_quirk_true(Quirks::OPT_BAD);
+            }
+
+            tcp_sig.ts1 = u32::from_be((*tcp_opt_tstamp).u32_1);
+            tcp_sig.set_quirk(Quirks::OPT_ZERO_TS1, tcp_sig.ts1 == 0);
+            tcp_sig.set_quirk(Quirks::OPT_NZ_TS2, (*tcp_opt_tstamp).u32_2 != 0);
+
+            if *tcp_option_pos + 10 > data_end {
+                return true;
+            }
+            *tcp_option_pos += 9;
+        },
+
+        // NOP is a single-byte option that does nothing
+        // others just keep move forward
+        _other => {}
+    };
+
+    false
+}
+
+// #[inline(always)]
+#[inline(never)]
+fn parse_ipv4_tcp_signatures(
+    ctx: &XdpContext,
+    ip_header: &iphdr,
+    tcp_sig: &mut TcpSignature,
+) -> bool {
+    let header_len = ip_header.ihl() as usize * 4;
+    if header_len < core::mem::size_of::<iphdr>() {
+        return false;
+    }
+
+    let tcp_header: *const tcphdr = {
+        let addr = ip_header as *const iphdr as usize + header_len;
+        if ip_header.protocol as u32 != IPPROTO_TCP
+            || addr + core::mem::size_of::<tcphdr>() > ctx.data_end()
+        {
+            return false;
+        } else {
+            addr as *const tcphdr
+        }
+    };
+
+    let tcp_header = unsafe { tcp_header.as_ref() }.unwrap();
+    let dest_port = u16::from_be(tcp_header.dest);
+    if dest_port != p0f::HTTP_PORT && dest_port != p0f::HTTPS_PORT
+        || tcp_header.syn() == 0
+        || tcp_header.ack() != 0
+    {
+        return false;
+    }
+
+    // set IPv4 header signature
+    tcp_sig.ip_ver = 0x04;
+    tcp_sig.ttl = ip_header.ttl;
+    tcp_sig.ip_opt_len = header_len.saturating_sub(20) as u8;
+    tcp_sig.tot_hdr = header_len as u16;
+
+    // ECN is the last two bits of ToS
+    tcp_sig.set_quirk(Quirks::ECN, (ip_header.tos & (p0f::IP_TOS_ECN)) != 0);
+
+    let ip_flags = u16::from_be(ip_header.frag_off);
+    tcp_sig.set_quirk(Quirks::NZ_MBZ, (ip_flags & p0f::IP4_MBZ) != 0);
+    if (ip_flags & p0f::IP4_DF) != 0 {
+        tcp_sig.set_quirk_true(Quirks::DF);
+        tcp_sig.set_quirk(Quirks::NZ_ID, ip_header.id != 0);
+    } else {
+        tcp_sig.set_quirk(Quirks::ZERO_ID, ip_header.id == 0);
+    }
+
+    parse_tcp_signature(ctx, &tcp_header, tcp_sig)
+}
+
+#[xdp("p0f_extractor")]
+pub fn p0f_extractor(ctx: XdpContext) -> XdpResult {
+    let mut tcp_sig = TcpSignature::default();
+    let eth = ctx.eth()?;
+    unsafe {
+        if (*eth).h_proto == u16::from_be(ETH_P_IP as u16) {
+            let ip_header: *const iphdr = ctx.ptr_after(eth)?;
+
+            if parse_ipv4_tcp_signatures(&ctx, &*ip_header, &mut tcp_sig) {
+                tcp_signatures.insert(&ctx, &MapData::new(tcp_sig));
+            }
+        } else {
+            // might other process, e.g. IPv6
+            return Ok(XdpAction::Pass);
+        };
+    }
+
+    Ok(XdpAction::Pass)
+}

--- a/examples/example-probes/src/p0f/main.rs
+++ b/examples/example-probes/src/p0f/main.rs
@@ -70,6 +70,8 @@ fn parse_tcp_signature(ctx: &XdpContext, tcp_header: &tcphdr, tcp_sig: &mut TcpS
     true
 }
 
+// this function is tedious, especially the way handle tcp_option_pos, it would be nice to find
+// a way to simplify it and pass the Linux BPF verifier
 #[inline(never)]
 // #[inline(always)]
 fn parse_tcp_option(

--- a/examples/example-probes/src/p0f/mod.rs
+++ b/examples/example-probes/src/p0f/mod.rs
@@ -1,0 +1,151 @@
+use core::mem;
+use redbpf_probes::{bindings::iphdr, bindings::tcphdr, xdp::prelude::*};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TcpSignature {
+    pub quirks: u32,     /* Quirks                             */
+    pub opt_eol_pad: u8, /* Amount of padding past EOL         */
+    pub ip_opt_len: u8,  /* Length of IP options               */
+    pub ip_ver: i8,      /* -1 = any, IP_VER4, IP_VER6         */
+    pub ttl: u8,         /* Actual TTL                         */
+
+    pub mss: i32, /* Maximum segment size (-1 = any)    */
+    pub win: u16, /* Window size                        */
+
+    pub win_type: u8,  /* WIN_TYPE_*                         */
+    pub pay_class: i8, /* -1 = any, 0 = zero, 1 = non-zero   */
+
+    pub wscale: i16,  /* Window scale (-1 = any)            */
+    pub tot_hdr: u16, /* Total header length                */
+    pub ts1: u32,     /* Own timestamp                      */
+
+    pub opt_cnt: u8,
+    pub options: [u8; MAX_TCP_OPT],
+}
+
+// names from p0f
+#[allow(non_camel_case_types)]
+pub enum Quirks {
+    /* IP-level quirks: */
+    ECN = 0x00000001,     /* ECN supported                      */
+    DF = 0x00000002,      /* DF used (probably PMTUD)           */
+    NZ_ID = 0x00000004,   /* Non-zero IDs when DF set           */
+    ZERO_ID = 0x00000008, /* Zero IDs when DF not set           */
+    NZ_MBZ = 0x00000010,  /* IP "must be zero" field isn't      */
+    FLOW = 0x00000020,    /* IPv6 flows used                    */
+
+    /* Core TCP quirks: */
+    ZERO_SEQ = 0x00001000, /* SEQ is zero                        */
+    NZ_ACK = 0x00002000,   /* ACK non-zero when ACK flag not set */
+    ZERO_ACK = 0x00004000, /* ACK is zero when ACK flag set      */
+    NZ_URG = 0x00008000,   /* URG non-zero when URG flag not set */
+    URG = 0x00010000,      /* URG flag set                       */
+    PUSH = 0x00020000,     /* PUSH flag on a control packet      */
+
+    /* TCP option quirks: */
+    OPT_ZERO_TS1 = 0x01000000, /* Own timestamp set to zero          */
+    OPT_NZ_TS2 = 0x02000000,   /* Peer timestamp non-zero on SYN     */
+    OPT_EOL_NZ = 0x04000000,   /* Non-zero padding past EOL          */
+    OPT_EXWS = 0x08000000,     /* Excessive window scaling           */
+    OPT_BAD = 0x10000000,      /* Problem parsing TCP options        */
+}
+
+// IP-level ECN, last two bits
+pub const IP_TOS_ECN: u8 = 0x03;
+
+/* IP flags: */
+pub const IP4_MBZ: u16 = 0x8000; /* "Must be zero"                  */
+pub const IP4_DF: u16 = 0x4000; /* Don't fragment (usually PMTUD)  */
+pub const IP4_MF: u16 = 0x2000; /* More fragments coming           */
+
+pub const MIN_TCP4: usize = mem::size_of::<iphdr>() + mem::size_of::<tcphdr>();
+pub const MIN_TCP6: usize = mem::size_of::<ipv6hdr>() + mem::size_of::<tcphdr>();
+
+pub const HTTP_PORT: u16 = 80;
+pub const HTTPS_PORT: u16 = 443;
+
+// tcp_sig_match uses 10, here use 11 to make TcpSignature 4 bytes aligned
+pub const MAX_TCP_OPT: usize = 11;
+pub const TCP_HDR_LEN: usize = mem::size_of::<tcphdr>();
+
+/* Notable options, aligned with p0f */
+pub const TCPOPT_EOL: u8 = 0; // End of options (1)
+pub const TCPOPT_NOP: u8 = 1; // No-op (1)
+pub const TCPOPT_MSS: u8 = 2; // Maximum segment size (4)
+pub const TCPOPT_WSCALE: u8 = 3; // Window scaling (3)
+pub const TCPOPT_SACKOK: u8 = 4; // Selective ACK permitted (2)
+pub const TCPOPT_SACK: u8 = 5; // Actual selective ACK (10-34)
+pub const TCPOPT_TSTAMP: u8 = 8; // Timestamp (10)
+
+/* Methods for matching window size in tcp_sig: */
+pub const WIN_TYPE_NORMAL: u8 = 0x00; /* Literal value                      */
+pub const WIN_TYPE_ANY: u8 = 0x01; /* Wildcard (p0f.fp sigs only)        */
+pub const WIN_TYPE_MOD: u8 = 0x02; /* Modulo check (p0f.fp sigs only)    */
+pub const WIN_TYPE_MSS: u8 = 0x03; /* Window size MSS multiplier         */
+pub const WIN_TYPE_MTU: u8 = 0x04; /* Window size MTU multiplier         */
+
+impl TcpSignature {
+    pub fn default() -> Self {
+        TcpSignature {
+            quirks: 0,
+            opt_eol_pad: 0,
+            ip_opt_len: 0,
+            ip_ver: 0,
+            ttl: 0,
+            mss: 0,
+            win: 0,
+            win_type: WIN_TYPE_NORMAL,
+            pay_class: -1,
+            wscale: 0,
+            tot_hdr: 0,
+            ts1: 0,
+            opt_cnt: 0,
+            options: [0; MAX_TCP_OPT],
+        }
+    }
+
+    #[inline]
+    pub fn set_quirk(&mut self, quirk: Quirks, cond: bool) {
+        // only set quirk when cond is true
+        if cond {
+            self.quirks |= quirk as u32;
+        }
+    }
+
+    #[inline]
+    pub fn set_quirk_true(&mut self, quirk: Quirks) {
+        self.quirks |= quirk as u32;
+    }
+
+    #[inline]
+    pub fn add_opt(&mut self, opt: u8) {
+        // it is always safe because the tcp option loop count <= MAX_TCP_OPT
+        self.options[self.opt_cnt as usize] = opt;
+        self.opt_cnt += 1;
+    }
+}
+
+#[repr(C, packed)]
+pub struct TcpOptionMss {
+    pub len: u8,
+    pub mss: i16,
+}
+
+#[repr(C, packed)]
+pub struct TcpOptionWscale {
+    pub len: u8,
+    pub wscale: u8,
+}
+
+#[repr(C, packed)]
+pub struct TcpOptionSackok {
+    pub len: u8,
+}
+
+#[repr(C, packed)]
+pub struct TcpOptionU32 {
+    pub len: u8,
+    pub u32_1: u32,
+    pub u32_2: u32,
+}

--- a/examples/example-userspace/examples/p0f.rs
+++ b/examples/example-userspace/examples/p0f.rs
@@ -1,0 +1,49 @@
+// for details about the p0f, please refer to https://github.com/p0f/p0f
+
+use futures::stream::StreamExt;
+use probes::p0f::TcpSignature;
+use redbpf::{load::Loader, xdp};
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(env!("OUT_DIR"), "/target/bpf/programs/p0f/p0f.elf"))
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> std::result::Result<(), String> {
+    let xdp_mode = xdp::Flags::DrvMode;
+    let interfaces: Vec<String> = vec!["eth0".to_string()];
+
+    let mut loaded = Loader::load(probe_code()).map_err(|err| format!("{:?}", err))?;
+
+    for interface in &interfaces {
+        println!("Attach p0f on interface: {} with mode {:?}", interface, xdp_mode);
+        for prog in loaded.xdps_mut() {
+            prog.attach_xdp(interface, xdp_mode)
+                .map_err(|err| format!("{:?}", err))?;
+        }
+    }
+
+    let _ = tokio::spawn(async move {
+        while let Some((name, events)) = loaded.events.next().await {
+            for event in events {
+                match name.as_str() {
+                    "tcp_signatures" => {
+                        let tcp_sig =
+                            unsafe { std::ptr::read(event.as_ptr() as *const TcpSignature) };
+                        println!("tcp_signature = {:?}", tcp_sig);
+                    }
+
+                    "log_events" => {
+                        let log_value = unsafe { std::ptr::read(event.as_ptr() as *const usize) };
+                        println!("read log_value = {}", log_value);
+                    }
+
+                    _ => panic!("unexpected event"),
+                }
+            }
+        }
+    })
+    .await;
+
+    Ok(())
+}

--- a/examples/example-userspace/examples/p0f.rs
+++ b/examples/example-userspace/examples/p0f.rs
@@ -29,7 +29,7 @@ async fn main() -> std::result::Result<(), String> {
                 match name.as_str() {
                     "tcp_signatures" => {
                         let tcp_sig =
-                            unsafe { std::ptr::read(event.as_ptr() as *const TcpSignature) };
+                            unsafe { std::ptr::read_unaligned(event.as_ptr() as *const TcpSignature) };
                         println!("tcp_signature = {:?}", tcp_sig);
                     }
 


### PR DESCRIPTION
add p0f extract as one example, while it can only support 5 TCP options and more options would lead to BPF app too complex that failed the Linux BPF verifier.

hope it could be simplified and pass the Linux verifier.

Signed-off-by: Kevin Sun <ksun@darwinium.com>