### PR TITLE
redbpf-probes: add support for XSKMAP eBPF Maps

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -263,7 +263,7 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
             } else {
                 // without generic types
                 match map_type_name.as_str() {
-                    "StackTrace" | "SockMap" | "ProgramArray" | "DevMap" => {}
+                    "StackTrace" | "SockMap" | "ProgramArray" | "DevMap" | "XskMap" => {}
                     _ => {
                         panic!("unknown map type name: {}", map_type_name);
                     }

--- a/redbpf-probes/src/xdp/mod.rs
+++ b/redbpf-probes/src/xdp/mod.rs
@@ -36,8 +36,10 @@ fn block_port_80(ctx: XdpContext) -> XdpResult {
  */
 pub mod prelude;
 mod devmap;
+mod xskmap;
 
 pub use devmap::DevMap;
+pub use xskmap::XskMap;
 
 use crate::bindings::*;
 use crate::maps::{PerfMap as PerfMapBase, PerfMapFlags};

--- a/redbpf-probes/src/xdp/xskmap.rs
+++ b/redbpf-probes/src/xdp/xskmap.rs
@@ -1,0 +1,49 @@
+use core::mem;
+use cty::c_void;
+use crate::xdp::{
+  bpf_map_def, bpf_map_type_BPF_MAP_TYPE_XSKMAP, XdpAction,
+  prelude::bpf_redirect_map,
+};
+
+/// AF_XDP socket map.
+///
+/// XskMap is an array-like map which may be used to redirect a packet to a target
+/// AF_XDP socket in user-level code. Its values are socket file descriptors.
+/// This is a wrapper for `BPF_MAP_TYPE_XSKMAP`.
+#[repr(transparent)]
+pub struct XskMap {
+    def: bpf_map_def,
+}
+
+impl XskMap {
+    /// Creates an AF_XDP socket map with the specified maximum number of elements.
+    pub const fn with_max_entries(max_entries: u32) -> Self {
+        Self {
+            def: bpf_map_def {
+                type_: bpf_map_type_BPF_MAP_TYPE_XSKMAP,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<u32>() as u32,
+                max_entries,
+                map_flags: 0,
+            },
+        }
+    }
+
+    /// Redirects the packet to the AF_XDP socket referenced at key `key`.
+    /// Returns Ok if socket was found for specified key. XDP probe
+    /// must return XdpAction::Redirect to actually redirect packet.
+    /// If key is not found, Err is returned.
+    #[inline]
+    pub fn redirect(&mut self, key: u32) -> Result<(), ()> {
+        let res = bpf_redirect_map(
+            &mut self.def as *mut _ as *mut c_void,
+            key, XdpAction::Aborted as u64
+        );
+        if res == XdpAction::Redirect as i64 {
+          Ok(())
+        } else {
+          Err(())
+        }
+    }
+}
+


### PR DESCRIPTION
This commit adds support for XskMap datastructures (BPF_MAP_TYPE_XSKMAP),
allowing the use of redbpf-generated binaries in AF_XDP programs.

This mostly repurposes the existing `DevMap` code as the redirect logic
is mostly identical.

Signed-off-by: Kyle Simpson <kyleandrew.simpson@gmail.com>