### PR TITLE
Check if tc_action program contains relocation for another section

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -42,6 +42,7 @@ cfg-if = "1.0"
 rustversion = "1.0"
 rustc_version = "0.4.0"
 semver = "1.0.0"
+goblin = "0.4.3"
 
 [build-dependencies]
 regex = "1.0.0"


### PR DESCRIPTION
`tc` utility does not support relocation for `.rodata` section.
So if `map.get(&42)` is written in the probe, an error occurs when `tc` loads
the probe.
This PR prevents users from writing invalid code like `map.get(&42)` by raising
a compile error with a descriptive error message.