### PR TITLE
Fix to keep supporting struct request of the newer kernel

### DIFF
--- a/examples/example-probes/include/bindings.h
+++ b/examples/example-probes/include/bindings.h
@@ -22,6 +22,7 @@
 #include <linux/math64.h>
 #include <linux/blk_types.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/time64.h>
 
 #endif

--- a/redbpf-tools/Cargo.toml
+++ b/redbpf-tools/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/foniod/redbpf"
 publish = false
 
 [build-dependencies]
-cargo-bpf = { path = "../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { path = "../cargo-bpf", default-features = false, features = ["build", "llvm-sys"] }
 
 [dependencies]
 probes = { path = "./probes" }

--- a/redbpf-tools/probes/include/bindings.h
+++ b/redbpf-tools/probes/include/bindings.h
@@ -13,4 +13,5 @@
 #define asm_inline asm
 #endif
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #endif


### PR DESCRIPTION
In the Linux kernel 5.16, `struct request` has been moved to `blk-mq.h` from `blkdev.h`.
Include blk-mq.h to fix compile error in new kernels.