### PR TITLE
Avoid linking of BPF programs

### DIFF
--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -197,10 +197,7 @@ fn build_probe(
         .arg("--")
         .arg("--cfg")
         .arg(version)
-        .args(
-            "--emit=llvm-bc -C panic=abort -C lto -C link-arg=-nostartfiles -C opt-level=3"
-                .split(' '),
-        )
+        .args("--emit=llvm-bc -C panic=abort -C lto -C opt-level=3 -C linker=true".split(' ')) // /usr/bin/true or /bin/true
         .arg("-g") // To generate .BTF section
         .arg("-o")
         .arg(artifacts_dir.join(probe).to_str().unwrap())


### PR DESCRIPTION
Linking does not create any useful stuff. ELF object file that contains
BPF programs are already generated before the linking step so it is okay
to ignore the linking procedure.

Instead of executing ld to link BPF programs, run the `true` command to
do nothing successfully.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>