### PR TITLE
Improve the echo example program that uses SockMap

### DIFF
--- a/examples/example-probes/src/echo/main.rs
+++ b/examples/example-probes/src/echo/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+/// This example program shows how to redirect packet using sockmap.
 use core::mem;
 use core::ptr;
 use memoffset::offset_of;
@@ -16,37 +17,35 @@ static mut ECHO_SOCKMAP: SockMap = SockMap::with_max_entries(10240);
 static mut IDX_MAP: HashMap<IdxMapKey, u32> = HashMap::with_max_entries(1024);
 
 #[stream_parser]
-fn parse_message_boundary(skb: SkBuff) -> StreamParserResult {
-    let len: u32 = unsafe {
-        let addr = (skb.skb as usize + offset_of!(__sk_buff, len)) as *const u32;
-        ptr::read(addr)
-    };
-    printk!("length: %u", len);
+unsafe fn parse_message_boundary(skb: SkBuff) -> StreamParserResult {
+    let len = (*skb.skb).len;
+    printk!("message length: %u", len);
     Ok(StreamParserAction::MessageLength(len))
 }
 
 #[stream_verdict]
-fn verdict(skb: SkBuff) -> SkAction {
-    let (ip, port) = unsafe {
-        let ip_addr = (skb.skb as usize + offset_of!(__sk_buff, remote_ip4)) as *const u32;
-        let port_addr = (skb.skb as usize + offset_of!(__sk_buff, remote_port)) as *const u32;
-        (ptr::read(ip_addr), ptr::read(port_addr))
-    };
+unsafe fn verdict(skb: SkBuff) -> SkAction {
+    let ip = (*skb.skb).remote_ip4;
+    let port = (*skb.skb).remote_port;
 
     printk!("ip: %x", u32::from_be(ip));
     printk!("port: %u", u32::from_be(port));
 
-    let mut idx = 0;
-    match unsafe {
-        let key = IdxMapKey { addr: ip, port };
-        IDX_MAP.get(&key)
-    } {
-        None => return SkAction::Drop,
-        Some(index) => idx = *index,
-    }
+    let idx = if let Some(index) = IDX_MAP.get(&IdxMapKey { addr: ip, port }) {
+        *index
+    } else {
+        printk!("drop packet since addr not found in idx map");
+        return SkAction::Drop;
+    };
 
-    match unsafe { ECHO_SOCKMAP.redirect(skb.skb as *mut _, idx) } {
-        Ok(_) => SkAction::Pass,
-        Err(_) => SkAction::Drop,
+    match ECHO_SOCKMAP.redirect(skb.skb as *mut _, idx) {
+        Ok(_) => {
+            printk!("redirect success");
+            SkAction::Pass
+        }
+        Err(_) => {
+            printk!("drop packet since redirect failed");
+            SkAction::Drop
+        }
     }
 }

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -2631,6 +2631,10 @@ impl<'a> SockMap<'a> {
             )
         };
         if ret < 0 {
+            error!(
+                "error on updating sockmap: {:?}",
+                io::Error::last_os_error()
+            );
             Err(Error::Map)
         } else {
             Ok(())


### PR DESCRIPTION
Update sockmap with a new socket descriptor before any data is read from
the descriptor or before some epoll event about the descriptor
occurs. Because setting sockmap fails if those events happens before.

Read all remaining data from the socket and write it to the client to
serve the echo task. This happens when setting sockmap fails because the
connection is already half closed.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>