### PR TITLE
Add ability to use interface index for attaching/detaching

### DIFF
--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -198,7 +198,7 @@ pub struct TracePoint {
 /// Type to work with `XDP` programs.
 pub struct XDP {
     common: ProgramData,
-    interfaces: Vec<String>,
+    interfaces: Vec<u32>,
 }
 
 /// Type to work with `stream_parser` BPF programs.
@@ -987,11 +987,27 @@ impl XDP {
     /// # }
     /// ```
     pub fn attach_xdp(&mut self, interface: &str, flags: xdp::Flags) -> Result<()> {
+        self.attach_xdp_by_index(if_nametoindex(interface)?, flags)
+    }
+
+    /// Attach the XDP program to interface by it's index.
+    ///
+    /// Attach the XDP program to the given network interface.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redbpf::{Module, xdp};
+    /// # let mut module = Module::parse(&std::fs::read("file.elf").unwrap()).unwrap();
+    /// # for uprobe in module.xdps_mut() {
+    /// uprobe.attach_xdp_by_index(2, xdp::Flags::default()).unwrap();
+    /// # }
+    /// ```
+    pub fn attach_xdp_by_index(&mut self, ifindex: u32, flags: xdp::Flags) -> Result<()> {
         let fd = self.common.fd.ok_or(Error::ProgramNotLoaded)?;
-        self.interfaces.push(interface.to_string());
-        if let Err(e) = unsafe { attach_xdp(interface, fd, flags as u32) } {
+        self.interfaces.push(ifindex);
+        if let Err(e) = unsafe { attach_xdp(ifindex, fd, flags as u32) } {
             if let Error::IO(oserr) = e {
-                error!("error attaching xdp to interface {}: {}", interface, oserr);
+                error!("error attaching xdp to interface #{}: {}", ifindex, oserr);
             }
             Err(Error::BPF)
         } else {
@@ -1013,18 +1029,35 @@ impl XDP {
     /// # }
     /// ```
     pub fn detach_xdp(&mut self, interface: &str) -> Result<()> {
+        self.detach_xdp_by_index(if_nametoindex(interface)?)
+    }
+
+    /// Detach the XDP program from interface by it's index.
+    ///
+    /// Detach the XDP program from the given network interface, if attached.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redbpf::{Module, xdp};
+    /// # let mut module = Module::parse(&std::fs::read("file.elf").unwrap()).unwrap();
+    /// # for uprobe in module.xdps_mut() {
+    /// uprobe.attach_xdp_by_index(23, xdp::Flags::default()).unwrap();
+    /// uprobe.detach_xdp_by_index(23).unwrap();
+    /// # }
+    /// ```
+    pub fn detach_xdp_by_index(&mut self, ifindex: u32) -> Result<()> {
         // The linear search here isn't great, but self.interfaces will almost always be short.
         let index = self
             .interfaces
             .iter()
             .enumerate()
-            .find_map(|(i, v)| (v.as_str() == interface).then(|| i))
+            .find_map(|(i, v)| (*v == ifindex).then(|| i))
             .ok_or(Error::ProgramNotLoaded)?;
-        if let Err(e) = unsafe { detach_xdp(interface) } {
+        if let Err(e) = unsafe { detach_xdp(ifindex) } {
             if let Error::IO(ref oserr) = e {
                 error!(
-                    "error detaching xdp from interface {}: {}",
-                    interface, oserr
+                    "error detaching xdp from interface #{}: {}",
+                    ifindex, oserr
                 );
             }
             return Err(e);
@@ -1040,8 +1073,8 @@ impl XDP {
 
 impl Drop for XDP {
     fn drop(&mut self) {
-        for interface in self.interfaces.iter() {
-            let _ = unsafe { detach_xdp(interface) };
+        for ifindex in self.interfaces.iter() {
+            let _ = unsafe { detach_xdp(*ifindex) };
         }
     }
 }
@@ -1084,21 +1117,24 @@ unsafe fn open_raw_sock(name: &str) -> Result<RawFd> {
     Ok(sock)
 }
 
-unsafe fn attach_xdp(dev_name: &str, progfd: libc::c_int, flags: libc::c_uint) -> Result<()> {
+fn if_nametoindex(dev_name: &str) -> Result<u32> {
     let ciface = CString::new(dev_name).unwrap();
-    let ifindex = libc::if_nametoindex(ciface.as_ptr()) as i32;
+    let ifindex = unsafe { libc::if_nametoindex(ciface.as_ptr()) };
     if ifindex == 0 {
         return Err(Error::IO(io::Error::last_os_error()));
     }
+    Ok(ifindex)
+}
 
-    if libbpf_sys::bpf_set_link_xdp_fd(ifindex, progfd, flags) != 0 {
+unsafe fn attach_xdp(ifindex: u32, progfd: libc::c_int, flags: libc::c_uint) -> Result<()> {
+    if libbpf_sys::bpf_set_link_xdp_fd(ifindex as i32, progfd, flags) != 0 {
         return Err(Error::IO(io::Error::last_os_error()));
     }
     Ok(())
 }
 
-unsafe fn detach_xdp(dev_name: &str) -> Result<()> {
-    attach_xdp(dev_name, -1, 0)
+unsafe fn detach_xdp(ifindex: u32) -> Result<()> {
+    attach_xdp(ifindex, -1, 0)
 }
 
 impl SocketFilter {


### PR DESCRIPTION
In some cases there is already interface index and user is forced
to convert it to interface name just for RedBPF to immediately
resolve it back to interface index.
Moreover, interface indices are stable, while name of interface
may change on the fly.