### PR TITLE
Parse WSL kernel versions

### DIFF
--- a/bpf-sys/src/uname.rs
+++ b/bpf-sys/src/uname.rs
@@ -66,10 +66,10 @@ fn parse_version(version: &str) -> Option<(u32, u32, u32)> {
     if let Some(version) = version.splitn(2, '-').next() {
         if let Some(version) = version.splitn(2, '+').next() {
             let parts: Vec<_> = version
-                .splitn(3, '.')
+                .splitn(4, '.')
                 .filter_map(|v| u32::from_str(v).ok())
                 .collect();
-            if parts.len() != 3 {
+            if parts.len() < 3 {
                 return None;
             }
             return Some((parts[0], parts[1], parts[2]));
@@ -85,6 +85,7 @@ mod test {
 
     #[test]
     fn test_parse_version() {
+        assert_eq!(parse_version("5.10.93.2-microsoft-standard-WSL2"), Some((5, 10, 93)));
         assert_eq!(parse_version("4.15.18"), Some((4, 15, 18)));
         assert_eq!(parse_version("4.15.1-generic"), Some((4, 15, 1)));
         assert_eq!(parse_version("4.15.1-generic-foo"), Some((4, 15, 1)));


### PR DESCRIPTION
Parse WSL kernel versions, which have 4 parts versus the standard 3.

Fixes #284