### PR TITLE
Implement Clone for Map

### DIFF
--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -313,6 +313,19 @@ pub struct Map {
     pin_file: Option<Box<Path>>,
 }
 
+impl Clone for Map {
+    fn clone(&self) -> Self {
+        Map {
+            name: self.name.clone(),
+            kind: self.kind,
+            fd: unsafe { libc::dup(self.fd) },
+            config: self.config.clone(),
+            section_data: self.section_data,
+            pin_file: self.pin_file.clone(),
+        }
+    }
+}
+
 enum MapBuilder<'a> {
     Normal {
         name: String,


### PR DESCRIPTION
This allows to share maps across threads/processes.
It's safe to use `libc::dup` in this case per [BPF manpages](https://man7.org/linux/man-pages/man2/bpf.2.html):

> File descriptors referring to eBPF objects can be duplicated in the usual way, using [dup(2)](https://man7.org/linux/man-pages/man2/dup.2.html) and similar calls.  An eBPF object is deallocated only after all file descriptors referring to the object have been closed.
