### PR TITLE
Use libbpf-sys with semver versioning scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,9 +437,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libbpf-sys"
-version = "0.6.1-2"
+version = "0.6.2+v0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df746ec055dfd68b3d0e8ea8dd12882157529132652d0df2e001305ba4803f0c"
+checksum = "1c2c15bbeae2b87e3a63feea85a579272ed082f0f4d8f0e7968cc9a17e1b4d69"
 dependencies = [
  "cc",
  "pkg-config",

--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -16,7 +16,7 @@ zero = "0.1"
 libc = "0.2"
 regex = { version = "1.5" }
 glob = "0.3.0"
-libbpf-sys = "0.6.1-2"
+libbpf-sys = "0.6.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["command-line"]
 clap = { version = "2.33", optional = true }
 bindgen = {version = "0.59.2", default-features = false, features = ["runtime"], optional = true}
 toml_edit = { version = "0.2", optional = true }
-libbpf-sys = { version = "0.6.1-2", optional = true }
+libbpf-sys = { version = "0.6.2", optional = true }
 bpf-sys = { version = "2.3.0", path = "../bpf-sys", optional = true }
 redbpf = { version = "2.3.0", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -18,7 +18,7 @@ ufmt = { version = "0.1.0", default-features = false }
 [build-dependencies]
 cargo-bpf = { version = "2.3.0", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
 bpf-sys = { version = "2.3.0", path = "../bpf-sys" }
-libbpf-sys = "0.6.1-2"
+libbpf-sys = "0.6.2"
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
 glob = "0.3.0"

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bpf-sys = { path = "../bpf-sys", version = "2.3.0" }
-libbpf-sys = "0.6.1-2"
+libbpf-sys = "0.6.2"
 goblin = "0.4"
 zero = "0.1"
 libc = "0.2"


### PR DESCRIPTION
libbpf-sys recently migrated to new versioning scheme which is semver-compatible. Latest release was republished with new versioning scheme. It will allow to use redbpf together with other crates depending on libbpf-sys in same project.
