### PR TITLE
Only set BTF key/value id if size is nonzero (fixes #327)

### DIFF
--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -1877,8 +1877,12 @@ impl Map {
             (*attr_ptr).max_entries = config.max_entries;
             if let Some(type_id) = btf_type_id.as_ref() {
                 (*attr_ptr).btf_fd = type_id.btf_fd as u32;
-                (*attr_ptr).btf_key_type_id = type_id.key_type_id;
-                (*attr_ptr).btf_value_type_id = type_id.value_type_id;
+                if config.key_size != 0 {
+                    (*attr_ptr).btf_key_type_id = type_id.key_type_id;
+                }
+                if config.value_size != 0 {
+                    (*attr_ptr).btf_value_type_id = type_id.value_type_id;
+                }
             }
             attr_uninit.assume_init()
         };


### PR DESCRIPTION
This is more of a workaround rather than an actual fix, but my kernel (`5.13.0-40-generic #45~20.04.1-Ubuntu SMP`) doesn't seem to like it when we supply BTF ids while the actual size of the map keys/values is zero. This seems to be what causes the invalid argument OS error in #327, hence this will fix #327. Couldn't see any obvious negative effects.