### PR TITLE
Improve support for tracepoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ programs using Rust. It includes:
 - Offers many BPF map types
   1. `HashMap`, `PerCpuHashMap`, `LruHashMap`, `LruPerCpuHashMap`, `Array`,
      `PerCpuArray`, `PerfMap`, `TcHashMap`, `StackTrace`, `ProgramArray`,
-     `SockMap`, `DevMap`
+     `SockMap`, `DevMap`, `RingBuf`
 - Offers several BPF program types
   1. `KProbe`, `KRetProbe`, `UProbe`, `URetProbe`, `SocketFilter`, `XDP`,
-     `StreamParser`, `StreamVerdict`, `TaskIter`, `SkLookup`
+     `StreamParser`, `StreamVerdict`, `TaskIter`, `SkLookup`, `Tracepoint`
 - Provides attribute macros that define various kind of BPF programs and BPF
   maps in a declarative way.
   1. `#[kprobe]`, `#[kretprobe]`, `#[uprobe]`, `#[uretprobe]`, `#[xdp]`,
      `#[tc_action]`, `#[socket_filter]`, `#[stream_parser]`,
-     `#[stream_verdict]`, `#[task_iter]`
+     `#[stream_verdict]`, `#[task_iter]`, `#[tracepoint]`
   2. `#[map]`
 - Can generate Rust bindings from the Linux kernel headers or from the BTF of
   `vmlinux`

--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -88,3 +88,8 @@ required-features = ["probes"]
 name = "bounded_loop"
 path = "src/bounded_loop/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "connection_tracer"
+path = "src/connection_tracer/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/build.rs
+++ b/examples/example-probes/build.rs
@@ -81,9 +81,9 @@ fn main() {
     // specify kernel headers in include/bindings.h, not here.
     builder = builder.header("include/bindings.h");
     // designate whitelist types
-    let types = ["request"];
+    let types = ["request", "sockaddr_in"];
     // allowing variables
-    let variables = ["NSEC_PER_MSEC", "NSEC_PER_USEC"];
+    let variables = ["NSEC_PER_MSEC", "NSEC_PER_USEC", "AF_INET"];
     for &ty in types.iter() {
         builder = builder.allowlist_type(ty);
     }

--- a/examples/example-probes/include/bindings.h
+++ b/examples/example-probes/include/bindings.h
@@ -24,5 +24,6 @@
 #include <linux/blkdev.h>
 #include <linux/blk-mq.h>
 #include <linux/time64.h>
+#include <linux/in.h>
 
 #endif

--- a/examples/example-probes/src/connection_tracer/main.rs
+++ b/examples/example-probes/src/connection_tracer/main.rs
@@ -1,0 +1,32 @@
+//! This example demonstrates how to use a tracepoint to trace the connect() system call
+//!
+//! See also the definition of the structs in `mod.rs`
+#![no_std]
+#![no_main]
+
+use core::mem::size_of;
+use example_probes::connection_tracer::SysEnterConnectArgs;
+use redbpf_probes::tracepoint::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[tracepoint]
+unsafe fn sys_enter_connect(args: *const SysEnterConnectArgs) {
+    let args = bpf_probe_read(args).expect("Failed to read arguments");
+    let addrlen = args.addrlen;
+    if addrlen < size_of::<sockaddr_in>() as u64 {
+        return;
+    }
+
+    let addr = args.useraddr;
+    let family = bpf_probe_read(addr as *const sa_family_t).unwrap_or(u16::MAX) as u32;
+    match family {
+        AF_INET => {
+            let sockaddr_struct = bpf_probe_read(addr as *const sockaddr_in).unwrap();
+            let ipv4 = &(sockaddr_struct.sin_addr.s_addr as u64) as *const u64;
+            bpf_trace_printk_raw(b"Connected to IPv4 address %pI4\0", ipv4 as u64, 0, 0)
+                .expect("printk failed");
+        }
+        _ => {}
+    };
+}

--- a/examples/example-probes/src/connection_tracer/mod.rs
+++ b/examples/example-probes/src/connection_tracer/mod.rs
@@ -1,0 +1,25 @@
+//! To read the input parameters for a tracepoint conveniently, define a struct
+//! to hold the input arguments. Refer to to
+//! `/sys/kernel/debug/tracing/events/<category>/<tracepoint>/format`
+//! for information about a specific tracepoint.
+
+#[repr(C, packed(1))]
+pub struct TracepointCommonArgs {
+    pub ctype: u16,
+    pub flags: u8,
+    pub preempt_count: u8,
+    pub pid: i32,
+}
+
+/// Members defined in `cat /sys/kernel/debug/tracing/events/syscalls/sys_enter_connect/format
+/// Note that offset addresses are important here, so ensure the compiler does not add padding.
+/// Any required padding will be set explicitly here.
+#[repr(C, packed(1))]
+pub struct SysEnterConnectArgs {
+    pub common: TracepointCommonArgs,
+    pub sys_nr: i32,
+    pad: u32,
+    pub fd: u64,
+    pub useraddr: u64,
+    pub addrlen: u64,
+}

--- a/examples/example-probes/src/lib.rs
+++ b/examples/example-probes/src/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(feature = "probes")]
 pub mod bindings;
 
+pub mod connection_tracer;
 pub mod echo;
 pub mod hashmaps;
 pub mod mallocstacks;

--- a/examples/example-userspace/examples/connection-tracer.rs
+++ b/examples/example-userspace/examples/connection-tracer.rs
@@ -1,0 +1,34 @@
+use libc;
+use std::process;
+use tokio::signal::ctrl_c;
+use tracing::{error, subscriber, Level};
+use tracing_subscriber::FmtSubscriber;
+use redbpf::load::Loader;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::geteuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let mut loaded = Loader::load(probe_code()).expect("error loading probe");
+    for tracepoint in loaded.tracepoints_mut() {
+        tracepoint.attach_trace_point("syscalls", "sys_enter_connect")
+            .expect(format!("error on attach_trace_point to {}", tracepoint.name()).as_str());
+    }
+
+    println!("Hit Ctrl-C to quit");
+    ctrl_c().await.expect("Error awaiting CTRL-C");
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/target/bpf/programs/connection_tracer/connection_tracer.elf"
+    ))
+}

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -498,6 +498,32 @@ pub fn uretprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     probe_impl("uretprobe", attrs, wrapper, name)
 }
 
+/// Attribute macro that must be used to define [`tracepoint probes`](https://www.kernel.org/doc/Documentation/trace/tracepoint-analysis.txt).
+///
+/// # Example
+///
+/// ```no_run
+/// use redbpf_probes::tracepoint::prelude::*;
+///
+/// #[tracepoint("syscalls:sys_enter_ioctl")]
+/// pub fn sys_enter_ioctl(args: *const c_void) {
+///     // do something here
+/// }
+/// ```
+///
+/// # Function parameters
+///
+/// The input parameter is a raw pointer to a struct containing tracepoint-specific members.
+/// Members and their offsets for your kernel can be found in (if debugfs is available)
+///
+/// `sudo cat /sys/kernel/debug/tracing/events/<category>/<tracepoint>/format`
+#[proc_macro_attribute]
+pub fn tracepoint(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let name = item.sig.ident.to_string();
+    probe_impl("tracepoint", attrs, item, name)
+}
+
 /// Attribute macro that must be used to define [`XDP` probes](https://www.iovisor.org/technology/xdp).
 ///
 /// See also the [`XDP` API provided by

--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -117,5 +117,6 @@ pub mod socket;
 pub mod socket_filter;
 pub mod sockmap;
 pub mod tc;
+pub mod tracepoint;
 pub mod uprobe;
 pub mod xdp;

--- a/redbpf-probes/src/tracepoint/mod.rs
+++ b/redbpf-probes/src/tracepoint/mod.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+/*!
+Tracepoint probes.
+
+[Tracepoints](https://www.kernel.org/doc/Documentation/trace/tracepoints.txt) are similar to [kprobes](super::kprobe), but without the ability
+to read CPU registers. Instead a tracepoint receives a fixed set of input arguments
+depending on the tracepoint. This makes tracepoints more stable across kernel versions
+and is less architecture-specific. However tracepoint probes can only be attached
+to a predetermined set of kernel functions (unlike kprobes that can be attached almost anywhere).
+
+There is no explicit return type for tracepoints (i.e. no kretprobe equivalent), but many kernel functions
+have tracepoints defined at function entry and exit.
+
+# Example
+Do something when ioctl system call is triggered. See the examples directory for a more
+complete scenario.
+
+```no_run
+#![no_std]
+#![no_main]
+use redbpf_probes::tracepoint::prelude::*;
+program!(0xFFFFFFFE, "GPL");
+#[tracepoint("syscalls:sys_enter_ioctl")]
+pub fn sys_enter_ioctl(args: *const c_void) {
+    // do something here
+    // ...
+}
+```
+ */
+pub mod prelude;

--- a/redbpf-probes/src/tracepoint/prelude.rs
+++ b/redbpf-probes/src/tracepoint/prelude.rs
@@ -1,0 +1,23 @@
+// Copyright 2022 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The Tracepoint Prelude
+//!
+//! The purpose of this module is to alleviate imports of the common tracepoint types
+//! by adding a glob import to the top of tracepoint programs:
+//!
+//! ```
+//! use redbpf_probes::tracepoint::prelude::*;
+//! ```
+pub use crate::bindings::*;
+pub use crate::helpers::*;
+pub use crate::maps::*;
+pub use crate::registers::*;
+#[cfg(feature = "ringbuf")]
+pub use crate::ringbuf::*;
+pub use cty::*;
+pub use redbpf_macros::{tracepoint, map, printk, program};

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -1033,7 +1033,6 @@ impl UProbe {
 impl TracePoint {
     pub fn attach_trace_point(&mut self, category: &str, name: &str) -> Result<()> {
         let fd = self.common.fd.ok_or(Error::ProgramNotLoaded)?;
-        // TODO Check this works correctly
         unsafe {
             let pfd = perf::open_tracepoint_perf_event(category, name)?;
             perf::attach_perf_event(fd, pfd)
@@ -1592,6 +1591,7 @@ impl<'a> ModuleBuilder<'a> {
                 | (hdr::SHT_PROGBITS, Some(kind @ "kretprobe"), Some(name))
                 | (hdr::SHT_PROGBITS, Some(kind @ "uprobe"), Some(name))
                 | (hdr::SHT_PROGBITS, Some(kind @ "uretprobe"), Some(name))
+                | (hdr::SHT_PROGBITS, Some(kind @ "tracepoint"), Some(name))
                 | (hdr::SHT_PROGBITS, Some(kind @ "xdp"), Some(name))
                 | (hdr::SHT_PROGBITS, Some(kind @ "socketfilter"), Some(name))
                 | (hdr::SHT_PROGBITS, Some(kind @ "streamparser"), Some(name))

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -13,7 +13,7 @@ use std::io;
 use std::path::Path;
 
 use crate::load::map_io::{PerfMessageStream, RingBufMessageStream};
-use crate::{cpus, Program};
+use crate::{cpus, Program, TracePoint};
 use crate::{
     Error, KProbe, Map, Module, PerfMap, RingBufMap, SkLookup, SocketFilter, StreamParser,
     StreamVerdict, TaskIter, UProbe, XDP,
@@ -201,5 +201,13 @@ impl Loaded {
 
     pub fn task_iter_mut(&mut self, name: &str) -> Option<&mut TaskIter> {
         self.module.task_iter_mut(name)
+    }
+
+    pub fn tracepoints_mut(&mut self) -> impl Iterator<Item = &mut TracePoint> {
+        self.module.trace_points_mut()
+    }
+
+    pub fn tracepoint_mut(&mut self, name: &str) -> Option<&mut TracePoint> {
+        self.module.trace_point_mut(name)
     }
 }

--- a/redbpf/src/perf.rs
+++ b/redbpf/src/perf.rs
@@ -223,6 +223,7 @@ pub(crate) unsafe fn open_tracepoint_perf_event(category: &str, name: &str) -> R
     let file = format!("/sys/kernel/debug/tracing/events/{}/{}/id", category, name);
     let tp_id = fs::read_to_string(&file)
         .expect(&format!("Cannot read {}", &file))
+        .trim()
         .parse::<i32>()
         .unwrap();
     if tp_id < 0 {


### PR DESCRIPTION
This adds a macro to aid in creating tracepoints, adds various documentation & an example for tracepoints and fixes a bug that prevented tracepoints from attaching.

This is essentially a light version of #124 which does not attempt to generate the tracepoint structs automatically. Instead users are expected to do this themselves. This is not entirely ideal, but given the issues #124 had with this I believe this is the simplest way to go.

This also does not change existing API functions and as such remains largely compatible.