### PR TITLE
Handle of missing structures in bindgen from sources

### DIFF
--- a/redbpf-probes/include/kernel_supplement.h
+++ b/redbpf-probes/include/kernel_supplement.h
@@ -1,0 +1,12 @@
+#ifndef KERNEL_SUPPLEMENT_H
+#define KERNEL_SUPPLEMENT_H
+
+/*
+This file is parsed only when building from Kernel source.
+Include here headers containing structures for which you'd
+like to generate binding for, not included in the other header files.
+*/
+
+#include <linux/fs_struct.h> // expose fs_struct
+
+#endif


### PR DESCRIPTION
Hello,

I noticed that fs_struct binding was missing while generating bindings from sources in redbpf-probes.
I propose a way, that I hope follow your standards to fix that.
Basically I created a file kernel_supplement.h where missing headers should be put when needed.
This file is used only when building from sources.

I also added accessors for `task_struct` and `fs_struct`

This patch has been tested on Archlinux and works for both vmlinux and kernel source building.